### PR TITLE
feat: add recurring events with biweekly preset and todo scheduling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "sonner";
 import ProtectedRoute from "./components/common/ProtectedRoute";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { EventProvider } from "./contexts/EventContext";
 import { TodoProvider } from "./contexts/TodoContext";
 import { useTheme } from "./hooks/useTheme";
 import DashboardPage from "./pages/DashboardPage";
@@ -27,29 +28,31 @@ export default function App() {
     <BrowserRouter basename="/CSC-710-AI-Calendar/">
       <AuthProvider>
         <ThemeProvider>
-          <TodoProvider>
-            <Routes>
-              <Route path="/" element={<LandingPage />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route
-                path="/dashboard"
-                element={
-                  <ProtectedRoute>
-                    <DashboardPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/settings"
-                element={
-                  <ProtectedRoute>
-                    <SettingsPage />
-                  </ProtectedRoute>
-                }
-              />
-            </Routes>
-            <ThemedToaster />
-          </TodoProvider>
+          <EventProvider>
+            <TodoProvider>
+              <Routes>
+                <Route path="/" element={<LandingPage />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute>
+                      <DashboardPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/settings"
+                  element={
+                    <ProtectedRoute>
+                      <SettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
+              </Routes>
+              <ThemedToaster />
+            </TodoProvider>
+          </EventProvider>
         </ThemeProvider>
       </AuthProvider>
     </BrowserRouter>

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import interactionPlugin from "@fullcalendar/interaction";
-import type { DatesSetArg, EventInput, EventMountArg } from "@fullcalendar/core";
+import type { DatesSetArg, EventMountArg } from "@fullcalendar/core";
+import { expandRecurringEvents } from "../../lib/rruleHelpers";
+import type { Event } from "../../types";
 
-// ─── Constants ──────────────────────────────────────────────────────────────
 const STORAGE_KEY = "dayforma-calendar-view";
 
 const VALID_VIEWS = new Set([
@@ -18,7 +19,6 @@ const VALID_VIEWS = new Set([
 
 const DEFAULT_VIEW = "dayGridMonth";
 
-/** Read the persisted view from localStorage (falls back to Month). */
 function getSavedView(): string {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
@@ -29,294 +29,70 @@ function getSavedView(): string {
   return DEFAULT_VIEW;
 }
 
-// ─── Mock events for Sprint 1 ──────────────────────────────────────────────
-// These will be replaced with live Supabase queries in a future sprint.
-const MOCK_EVENTS: EventInput[] = [
-  // ── Past events (early-to-mid April) ──────────────────────────────────────
-  {
-    id: "mock-p1",
-    title: "Project kickoff meeting",
-    start: "2026-04-01T10:00:00",
-    end: "2026-04-01T11:30:00",
-    backgroundColor: "#6366f1",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p2",
-    title: "Requirements gathering",
-    start: "2026-04-03T09:00:00",
-    end: "2026-04-03T10:00:00",
-    backgroundColor: "#0ea5e9",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p3",
-    title: "Sprint planning",
-    allDay: true,
-    start: "2026-04-05",
-    backgroundColor: "#8b5cf6",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p4",
-    title: "Database schema review",
-    start: "2026-04-07T14:00:00",
-    end: "2026-04-07T15:30:00",
-    backgroundColor: "#f97316",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p5",
-    title: "UI wireframe workshop",
-    start: "2026-04-09T11:00:00",
-    end: "2026-04-09T12:30:00",
-    backgroundColor: "#ec4899",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p6",
-    title: "API design discussion",
-    start: "2026-04-11T15:00:00",
-    end: "2026-04-11T16:00:00",
-    backgroundColor: "#10b981",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p7",
-    title: "Mid-sprint check-in",
-    start: "2026-04-14T09:30:00",
-    end: "2026-04-14T10:00:00",
-    backgroundColor: "#0ea5e9",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p8",
-    title: "Auth system review",
-    start: "2026-04-16T13:00:00",
-    end: "2026-04-16T14:00:00",
-    backgroundColor: "#f43f5e",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p9",
-    title: "Deployment setup",
-    allDay: true,
-    start: "2026-04-18",
-    backgroundColor: "#06b6d4",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p10",
-    title: "Team retrospective",
-    start: "2026-04-21T16:00:00",
-    end: "2026-04-21T17:00:00",
-    backgroundColor: "#f59e0b",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p11",
-    title: "Bug triage",
-    start: "2026-04-23T10:00:00",
-    end: "2026-04-23T11:00:00",
-    backgroundColor: "#f43f5e",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p12",
-    title: "Dashboard layout review",
-    start: "2026-04-25T14:00:00",
-    end: "2026-04-25T15:00:00",
-    backgroundColor: "#8b5cf6",
-    textColor: "#ffffff",
-  },
+const DEFAULT_VISIBLE_RANGE = {
+  start: new Date("2026-04-27T00:00:00"),
+  end: new Date("2026-06-01T00:00:00"),
+};
 
-  // ── This week (late April) ────────────────────────────────────────────────
+const MOCK_EVENTS: Event[] = [
   {
-    id: "mock-p13",
-    title: "Focus block",
-    start: "2026-04-27T10:00:00",
-    end: "2026-04-27T12:00:00",
-    backgroundColor: "#22c55e",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p14",
-    title: "Mentor 1-on-1",
-    start: "2026-04-27T14:00:00",
-    end: "2026-04-27T14:45:00",
-    backgroundColor: "#06b6d4",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p15",
-    title: "Release prep",
-    allDay: true,
-    start: "2026-04-28",
-    backgroundColor: "#f97316",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-p16",
-    title: "Supabase migration",
-    start: "2026-04-28T10:00:00",
-    end: "2026-04-28T12:00:00",
-    backgroundColor: "#22c55e",
-    textColor: "#ffffff",
-  },
-
-  // ── Today (April 29) ─────────────────────────────────────────────────────
-  {
-    id: "mock-t1",
-    title: "Team standup",
-    start: "2026-04-29T09:00:00",
-    end: "2026-04-29T09:30:00",
-    backgroundColor: "#0ea5e9",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-t2",
+    id: "mock-design-review",
+    user_id: "mock-user",
     title: "Design review",
-    start: "2026-04-29T14:00:00",
-    end: "2026-04-29T15:00:00",
-    backgroundColor: "#ec4899",
-    textColor: "#ffffff",
+    description: null,
+    start_at: "2026-04-29T14:00:00",
+    end_at: "2026-04-29T15:00:00",
+    all_day: false,
+    category_id: null,
+    rrule: null,
+    reminder_offset_minutes: null,
+    created_by_ai: false,
+    created_at: "2026-04-28T10:00:00",
+    updated_at: "2026-04-28T10:00:00",
   },
   {
-    id: "mock-t3",
-    title: "Evening study",
-    start: "2026-04-29T19:00:00",
-    end: "2026-04-29T20:30:00",
-    backgroundColor: "#8b5cf6",
-    textColor: "#ffffff",
-  },
-
-  // ── Tomorrow and rest of week ─────────────────────────────────────────────
-  {
-    id: "mock-f1",
-    title: "AI scheduling sync",
-    start: "2026-04-30T11:00:00",
-    end: "2026-04-30T12:00:00",
-    backgroundColor: "#8b5cf6",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-f2",
-    title: "Code review session",
-    start: "2026-04-30T15:30:00",
-    end: "2026-04-30T16:30:00",
-    backgroundColor: "#f59e0b",
-    textColor: "#ffffff",
-  },
-
-  // ── May events ────────────────────────────────────────────────────────────
-  {
-    id: "mock-m1",
-    title: "Sprint kickoff",
-    start: "2026-05-01T09:00:00",
-    end: "2026-05-01T10:00:00",
-    backgroundColor: "#0ea5e9",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m2",
-    title: "Voice prototype",
-    start: "2026-05-03T13:30:00",
-    end: "2026-05-03T15:00:00",
-    backgroundColor: "#f59e0b",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m3",
-    title: "Office hours",
-    start: "2026-05-06T10:00:00",
-    end: "2026-05-06T11:00:00",
-    backgroundColor: "#10b981",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m4",
-    title: "UX review",
-    start: "2026-05-09T11:00:00",
-    end: "2026-05-09T12:00:00",
-    backgroundColor: "#f43f5e",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m5",
-    title: "AI parser QA",
-    start: "2026-05-11T15:00:00",
-    end: "2026-05-11T16:30:00",
-    backgroundColor: "#8b5cf6",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m6",
+    id: "mock-demo-dry-run",
+    user_id: "mock-user",
     title: "Demo dry run",
-    start: "2026-05-14T14:00:00",
-    end: "2026-05-14T15:30:00",
-    backgroundColor: "#06b6d4",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m7",
-    title: "Database check-in",
-    start: "2026-05-17T16:00:00",
-    end: "2026-05-17T17:00:00",
-    backgroundColor: "#f97316",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m8",
-    title: "Study block",
-    start: "2026-05-20T18:30:00",
-    end: "2026-05-20T19:30:00",
-    backgroundColor: "#22c55e",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m9",
-    title: "Presentation polish",
-    start: "2026-05-23T12:00:00",
-    end: "2026-05-23T13:00:00",
-    backgroundColor: "#ec4899",
-    textColor: "#ffffff",
-  },
-  {
-    id: "mock-m10",
-    title: "Launch checklist",
-    start: "2026-05-29T17:00:00",
-    end: "2026-05-29T18:00:00",
-    backgroundColor: "#6366f1",
-    textColor: "#ffffff",
+    description: null,
+    start_at: "2026-05-14T14:00:00",
+    end_at: "2026-05-14T15:30:00",
+    all_day: false,
+    category_id: null,
+    rrule: null,
+    reminder_offset_minutes: null,
+    created_by_ai: false,
+    created_at: "2026-05-13T10:00:00",
+    updated_at: "2026-05-13T10:00:00",
   },
 ];
 
 interface CalendarViewProps {
-  /** Override the default mock events (for future live data). */
-  events?: EventInput[];
+  events?: Event[];
 }
 
-/**
- * FullCalendar multi-view wrapper with controlled view switching.
- *
- * Supports Month, Week, Day, and Agenda views. The last selected view
- * is persisted in localStorage so it survives page reloads.
- * Past events are visually dimmed via the .fc-event-past CSS class.
- */
 export default function CalendarView({ events = MOCK_EVENTS }: CalendarViewProps) {
   const calendarRef = useRef<FullCalendar>(null);
+  const [visibleRange, setVisibleRange] = useState(DEFAULT_VISIBLE_RANGE);
 
-  /** Persist the current view whenever the user switches. */
+  const concreteEvents = useMemo(
+    () => expandRecurringEvents(events, visibleRange),
+    [events, visibleRange]
+  );
+
   const handleDatesSet = useCallback((arg: DatesSetArg) => {
-    const viewType = arg.view.type;
     try {
-      localStorage.setItem(STORAGE_KEY, viewType);
+      localStorage.setItem(STORAGE_KEY, arg.view.type);
     } catch {
       /* localStorage may be unavailable */
     }
+
+    setVisibleRange({
+      start: arg.start,
+      end: arg.end,
+    });
   }, []);
 
-  /** Mark past events with a CSS class so they render dimmed. */
   const handleEventDidMount = useCallback((info: EventMountArg) => {
     const eventEnd = info.event.end ?? info.event.start;
     if (eventEnd && eventEnd < new Date()) {
@@ -343,7 +119,7 @@ export default function CalendarView({ events = MOCK_EVENTS }: CalendarViewProps
         }}
         datesSet={handleDatesSet}
         eventDidMount={handleEventDidMount}
-        events={events}
+        events={concreteEvents}
         height={720}
         editable={false}
         selectable={false}

--- a/src/contexts/EventContext.tsx
+++ b/src/contexts/EventContext.tsx
@@ -1,0 +1,212 @@
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react";
+import { toast } from "sonner";
+import { supabase } from "../lib/supabase";
+import { useAuth } from "../hooks/useAuth";
+import type { Event, RRulePreset } from "../types";
+
+interface EventState {
+  events: Event[];
+  loading: boolean;
+  error: string | null;
+}
+
+type EventAction =
+  | { type: "SET_EVENTS"; payload: Event[] }
+  | { type: "ADD_EVENT"; payload: Event }
+  | { type: "UPDATE_EVENT"; payload: Event }
+  | { type: "DELETE_EVENT"; payload: { id: string } }
+  | { type: "SET_LOADING"; payload: boolean }
+  | { type: "SET_ERROR"; payload: string | null };
+
+const initialEventState: EventState = {
+  events: [],
+  loading: true,
+  error: null,
+};
+
+function eventReducer(state: EventState, action: EventAction): EventState {
+  switch (action.type) {
+    case "SET_EVENTS":
+      return { ...state, events: action.payload };
+    case "ADD_EVENT":
+      if (state.events.some((event) => event.id === action.payload.id)) {
+        return state;
+      }
+      return { ...state, events: [...state.events, action.payload] };
+    case "UPDATE_EVENT": {
+      const index = state.events.findIndex((event) => event.id === action.payload.id);
+      if (index === -1) return state;
+      const next = state.events.slice();
+      next[index] = action.payload;
+      return { ...state, events: next };
+    }
+    case "DELETE_EVENT":
+      return { ...state, events: state.events.filter((event) => event.id !== action.payload.id) };
+    case "SET_LOADING":
+      return { ...state, loading: action.payload };
+    case "SET_ERROR":
+      return { ...state, error: action.payload };
+    default:
+      return state;
+  }
+}
+
+export interface CreateEventInput {
+  title: string;
+  description?: string | null;
+  start_at: string;
+  end_at: string;
+  all_day?: boolean;
+  category_id?: string | null;
+  rrule?: RRulePreset | null;
+  reminder_offset_minutes?: number | null;
+}
+
+export interface EventContextValue {
+  events: Event[];
+  loading: boolean;
+  error: string | null;
+  createEvent: (input: CreateEventInput) => Promise<string | null>;
+}
+
+export const EventContext = createContext<EventContextValue | null>(null);
+
+export function EventProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const [state, dispatch] = useReducer(eventReducer, initialEventState);
+  const eventsRef = useRef<Event[]>(state.events);
+  eventsRef.current = state.events;
+
+  useEffect(() => {
+    if (!user?.id) {
+      dispatch({ type: "SET_EVENTS", payload: [] });
+      dispatch({ type: "SET_LOADING", payload: false });
+      return;
+    }
+
+    let cancelled = false;
+    dispatch({ type: "SET_LOADING", payload: true });
+    dispatch({ type: "SET_ERROR", payload: null });
+
+    (async () => {
+      const { data, error } = await supabase
+        .from("events")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("start_at", { ascending: true });
+
+      if (cancelled) return;
+
+      if (error) {
+        dispatch({ type: "SET_ERROR", payload: error.message });
+        toast.error(`Failed to load events: ${error.message}`);
+      } else {
+        dispatch({ type: "SET_EVENTS", payload: (data ?? []) as Event[] });
+      }
+
+      dispatch({ type: "SET_LOADING", payload: false });
+    })();
+
+    const channel = supabase
+      .channel(`events:${user.id}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "events",
+          filter: `user_id=eq.${user.id}`,
+        },
+        (payload) => {
+          if (payload.eventType === "INSERT") {
+            dispatch({ type: "ADD_EVENT", payload: payload.new as Event });
+          } else if (payload.eventType === "UPDATE") {
+            dispatch({ type: "UPDATE_EVENT", payload: payload.new as Event });
+          } else if (payload.eventType === "DELETE") {
+            const old = payload.old as { id?: string };
+            if (old?.id) {
+              dispatch({ type: "DELETE_EVENT", payload: { id: old.id } });
+            }
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      supabase.removeChannel(channel);
+    };
+  }, [user?.id]);
+
+  const createEvent = useCallback(
+    async (input: CreateEventInput): Promise<string | null> => {
+      if (!user?.id) {
+        toast.error("Not signed in");
+        return null;
+      }
+
+      const id = crypto.randomUUID();
+      const now = new Date().toISOString();
+      const optimistic: Event = {
+        id,
+        user_id: user.id,
+        title: input.title,
+        description: input.description ?? null,
+        start_at: input.start_at,
+        end_at: input.end_at,
+        all_day: input.all_day ?? false,
+        category_id: input.category_id ?? null,
+        rrule: input.rrule ?? null,
+        reminder_offset_minutes: input.reminder_offset_minutes ?? null,
+        created_by_ai: false,
+        created_at: now,
+        updated_at: now,
+      };
+
+      dispatch({ type: "ADD_EVENT", payload: optimistic });
+
+      const { error } = await supabase.from("events").insert({
+        id,
+        user_id: user.id,
+        title: optimistic.title,
+        description: optimistic.description,
+        start_at: optimistic.start_at,
+        end_at: optimistic.end_at,
+        all_day: optimistic.all_day,
+        category_id: optimistic.category_id,
+        rrule: optimistic.rrule,
+        reminder_offset_minutes: optimistic.reminder_offset_minutes,
+      });
+
+      if (error) {
+        dispatch({ type: "DELETE_EVENT", payload: { id } });
+        toast.error(`Failed to create event: ${error.message}`);
+        return null;
+      }
+
+      toast.success("Event created");
+      return id;
+    },
+    [user?.id]
+  );
+
+  const value = useMemo<EventContextValue>(
+    () => ({
+      events: state.events,
+      loading: state.loading,
+      error: state.error,
+      createEvent,
+    }),
+    [state.events, state.loading, state.error, createEvent]
+  );
+
+  return <EventContext.Provider value={value}>{children}</EventContext.Provider>;
+}

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { EventContext } from "../contexts/EventContext";
+
+export function useEvents() {
+  const ctx = useContext(EventContext);
+  if (!ctx) {
+    throw new Error("useEvents must be used inside <EventProvider>");
+  }
+  return ctx;
+}

--- a/src/lib/rruleHelpers.ts
+++ b/src/lib/rruleHelpers.ts
@@ -1,0 +1,249 @@
+import type { EventInput } from "@fullcalendar/core";
+import type { Event, RRulePreset } from "../types";
+
+export type VisibleRange = {
+  start: Date;
+  end: Date;
+};
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function addMonths(date: Date, months: number): Date {
+  const next = new Date(date);
+  next.setMonth(next.getMonth() + months);
+  return next;
+}
+
+function startOfDay(date: Date): Date {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+function endOfDay(date: Date): Date {
+  const next = new Date(date);
+  next.setHours(23, 59, 59, 999);
+  return next;
+}
+
+function daysBetween(start: Date, end: Date): number {
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+  return Math.floor((startOfDay(end).getTime() - startOfDay(start).getTime()) / millisecondsPerDay);
+}
+
+function isWeekday(date: Date): boolean {
+  const day = date.getDay();
+  return day >= 1 && day <= 5;
+}
+
+function buildOccurrence(event: Event, startAt: Date, endAt: Date, occurrenceIndex: number): EventInput {
+  return {
+    id: `${event.id}::${occurrenceIndex}`,
+    groupId: event.id,
+    title: event.title,
+    start: startAt.toISOString(),
+    end: endAt.toISOString(),
+    allDay: event.all_day,
+    extendedProps: {
+      sourceEventId: event.id,
+      rrule: event.rrule,
+      occurrenceIndex,
+    },
+  };
+}
+
+function expandDaily(event: Event, range: VisibleRange, durationMs: number): EventInput[] {
+  const baseStart = new Date(event.start_at);
+  const firstOffset = Math.max(0, daysBetween(baseStart, range.start));
+  const first = addDays(baseStart, firstOffset);
+  const results: EventInput[] = [];
+
+  for (let cursor = first, index = firstOffset; cursor < range.end; cursor = addDays(cursor, 1), index += 1) {
+    const occurrenceEnd = new Date(cursor.getTime() + durationMs);
+    if (occurrenceEnd > range.start) {
+      results.push(buildOccurrence(event, cursor, occurrenceEnd, index));
+    }
+  }
+
+  return results;
+}
+
+function expandWeekly(event: Event, range: VisibleRange, durationMs: number, weekdays: number[]): EventInput[] {
+  const baseStart = new Date(event.start_at);
+  const allowed = new Set(weekdays);
+  const results: EventInput[] = [];
+  const cursor = startOfDay(range.start);
+  let occurrenceIndex = 0;
+
+  while (cursor < range.end) {
+    const candidate = new Date(cursor);
+    candidate.setHours(
+      baseStart.getHours(),
+      baseStart.getMinutes(),
+      baseStart.getSeconds(),
+      baseStart.getMilliseconds()
+    );
+
+    if (candidate >= baseStart && allowed.has(candidate.getDay())) {
+      const occurrenceEnd = new Date(candidate.getTime() + durationMs);
+      if (occurrenceEnd > range.start) {
+        results.push(buildOccurrence(event, candidate, occurrenceEnd, occurrenceIndex));
+      }
+      occurrenceIndex += 1;
+    }
+
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return results;
+}
+
+function expandMonthly(event: Event, range: VisibleRange, durationMs: number, dayOfMonth: number): EventInput[] {
+  const baseStart = new Date(event.start_at);
+  const results: EventInput[] = [];
+  let occurrenceIndex = 0;
+
+  for (
+    let cursor = new Date(baseStart.getFullYear(), baseStart.getMonth(), 1);
+    cursor < range.end;
+    cursor = addMonths(cursor, 1)
+  ) {
+    const candidate = new Date(cursor);
+    const maxDay = new Date(candidate.getFullYear(), candidate.getMonth() + 1, 0).getDate();
+    candidate.setDate(Math.min(dayOfMonth, maxDay));
+    candidate.setHours(
+      baseStart.getHours(),
+      baseStart.getMinutes(),
+      baseStart.getSeconds(),
+      baseStart.getMilliseconds()
+    );
+
+    if (candidate < baseStart) {
+      continue;
+    }
+
+    const occurrenceEnd = new Date(candidate.getTime() + durationMs);
+    if (candidate < range.end && occurrenceEnd > range.start) {
+      results.push(buildOccurrence(event, candidate, occurrenceEnd, occurrenceIndex));
+    }
+    occurrenceIndex += 1;
+  }
+
+  return results;
+}
+
+function expandWeekday(event: Event, range: VisibleRange, durationMs: number): EventInput[] {
+  const baseStart = new Date(event.start_at);
+  const results: EventInput[] = [];
+  const cursor = startOfDay(range.start);
+  let occurrenceIndex = 0;
+
+  while (cursor < range.end) {
+    const candidate = new Date(cursor);
+    candidate.setHours(
+      baseStart.getHours(),
+      baseStart.getMinutes(),
+      baseStart.getSeconds(),
+      baseStart.getMilliseconds()
+    );
+
+    if (candidate >= baseStart && isWeekday(candidate)) {
+      const occurrenceEnd = new Date(candidate.getTime() + durationMs);
+      if (occurrenceEnd > range.start) {
+        results.push(buildOccurrence(event, candidate, occurrenceEnd, occurrenceIndex));
+      }
+      occurrenceIndex += 1;
+    }
+
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return results;
+}
+
+function expandBiweekly(event: Event, range: VisibleRange, durationMs: number, weekdays: number[]): EventInput[] {
+  const baseStart = new Date(event.start_at);
+  const allowed = new Set(weekdays);
+  const results: EventInput[] = [];
+  const cursor = startOfDay(range.start);
+  let occurrenceIndex = 0;
+
+  while (cursor < range.end) {
+    const candidate = new Date(cursor);
+    candidate.setHours(
+      baseStart.getHours(),
+      baseStart.getMinutes(),
+      baseStart.getSeconds(),
+      baseStart.getMilliseconds()
+    );
+
+    if (candidate >= baseStart && allowed.has(candidate.getDay())) {
+      const weekOffset = Math.floor(daysBetween(startOfDay(baseStart), startOfDay(candidate)) / 7);
+      if (weekOffset % 2 === 0) {
+        const occurrenceEnd = new Date(candidate.getTime() + durationMs);
+        if (occurrenceEnd > range.start) {
+          results.push(buildOccurrence(event, candidate, occurrenceEnd, occurrenceIndex));
+        }
+        occurrenceIndex += 1;
+      }
+    }
+
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return results;
+}
+
+function expandPreset(event: Event, range: VisibleRange, durationMs: number, preset: RRulePreset): EventInput[] {
+  switch (preset.preset) {
+    case "daily":
+      return expandDaily(event, range, durationMs);
+    case "weekly":
+      return expandWeekly(event, range, durationMs, preset.weekdays);
+    case "biweekly":
+      return expandBiweekly(event, range, durationMs, preset.weekdays);
+    case "monthly":
+      return expandMonthly(event, range, durationMs, preset.day_of_month);
+    case "weekday":
+      return expandWeekday(event, range, durationMs);
+    default:
+      return [];
+  }
+}
+
+export function eventToCalendarInput(event: Event): EventInput {
+  return {
+    id: event.id,
+    groupId: event.id,
+    title: event.title,
+    start: event.start_at,
+    end: event.end_at,
+    allDay: event.all_day,
+    extendedProps: {
+      sourceEventId: event.id,
+      rrule: event.rrule,
+    },
+  };
+}
+
+export function expandRecurringEvents(events: Event[], range: VisibleRange): EventInput[] {
+  return events.flatMap((event) => {
+    if (!event.rrule) {
+      const startAt = new Date(event.start_at);
+      const endAt = new Date(event.end_at);
+      if (startAt < range.end && endAt > range.start) {
+        return [eventToCalendarInput(event)];
+      }
+      return [];
+    }
+
+    const startAt = new Date(event.start_at);
+    const endAt = new Date(event.end_at);
+    const durationMs = Math.max(30 * 60 * 1000, endAt.getTime() - startAt.getTime());
+    return expandPreset(event, { start: startOfDay(range.start), end: endOfDay(range.end) }, durationMs, event.rrule);
+  });
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,12 +1,13 @@
 import { useMemo, useState, type KeyboardEvent } from "react";
 import { useNavigate } from "react-router";
 import { format, isThisWeek, isToday, isTomorrow, parseISO } from "date-fns";
-import { Calendar, Check, LogOut, Pencil, Settings, Trash2 } from "lucide-react";
+import { Calendar, Check, LogOut, Pencil, Settings, Trash2, X } from "lucide-react";
 import { useAuth } from "../hooks/useAuth";
+import { useEvents } from "../hooks/useEvents";
 import { useTodos } from "../hooks/useTodos";
 import CalendarView from "../components/calendar/CalendarView";
 import ThemeToggle from "../components/common/ThemeToggle";
-import type { Priority, Todo } from "../types";
+import type { Event, Priority, RRulePreset, Todo } from "../types";
 
 type AgendaEvent = {
   title: string;
@@ -23,6 +24,17 @@ type TodoDraft = {
   priority: Priority;
 };
 
+type EventFormState = {
+  title: string;
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+  allDay: boolean;
+  recurrence: "none" | "daily" | "weekday" | "weekly" | "biweekly" | "monthly";
+  weekdays: number[];
+};
+
 const agenda: AgendaEvent[] = [
   { title: "Daily standup", time: "09:00", category: "Team", tone: "sky" },
   { title: "Calendar drop UX pass", time: "11:00", category: "Design", tone: "rose" },
@@ -36,6 +48,16 @@ const priorityOrder: Record<Priority, number> = {
   medium: 2,
   low: 3,
 };
+
+const weekdayOptions = [
+  { label: "Sun", value: 0 },
+  { label: "Mon", value: 1 },
+  { label: "Tue", value: 2 },
+  { label: "Wed", value: 3 },
+  { label: "Thu", value: 4 },
+  { label: "Fri", value: 5 },
+  { label: "Sat", value: 6 },
+];
 
 function priorityClasses(priority: Priority) {
   switch (priority) {
@@ -83,6 +105,55 @@ function toneClasses(tone: string) {
       return "bg-violet-100 text-violet-700 ring-violet-400/40 dark:bg-violet-500/15 dark:text-violet-200 dark:ring-violet-400/30";
     default:
       return "bg-slate-900/10 text-slate-700 ring-slate-900/15 dark:bg-white/10 dark:text-white dark:ring-white/15";
+  }
+}
+
+function toDateTime(date: string, time: string): string {
+  return `${date}T${time}:00`;
+}
+
+function getDefaultEventFormState(): EventFormState {
+  const now = new Date();
+  const startHour = `${String(Math.max(now.getHours() + 1, 9)).padStart(2, "0")}:00`;
+  const endHour = `${String(Math.max(now.getHours() + 2, 10)).padStart(2, "0")}:00`;
+  const isoDate = now.toISOString().slice(0, 10);
+
+  return {
+    title: "",
+    startDate: isoDate,
+    startTime: startHour,
+    endDate: isoDate,
+    endTime: endHour,
+    allDay: false,
+    recurrence: "none",
+    weekdays: [new Date(`${isoDate}T00:00:00`).getDay()],
+  };
+}
+
+function buildRRule(form: EventFormState): RRulePreset | null {
+  switch (form.recurrence) {
+    case "daily":
+      return { preset: "daily" };
+    case "weekday":
+      return { preset: "weekday" };
+    case "weekly":
+      return {
+        preset: "weekly",
+        weekdays: form.weekdays.length > 0 ? form.weekdays : [new Date(`${form.startDate}T00:00:00`).getDay()],
+      };
+    case "biweekly":
+      return {
+        preset: "biweekly",
+        weekdays: form.weekdays.length > 0 ? form.weekdays : [new Date(`${form.startDate}T00:00:00`).getDay()],
+      };
+    case "monthly":
+      return {
+        preset: "monthly",
+        day_of_month: new Date(`${form.startDate}T00:00:00`).getDate(),
+      };
+    case "none":
+    default:
+      return null;
   }
 }
 
@@ -159,11 +230,192 @@ function DashboardHeader({
   );
 }
 
-function CalendarPanel() {
+function EventComposer({
+  open,
+  form,
+  loading,
+  onClose,
+  onChange,
+  onToggleWeekday,
+  onSubmit,
+}: {
+  open: boolean;
+  form: EventFormState;
+  loading: boolean;
+  onClose: () => void;
+  onChange: (patch: Partial<EventFormState>) => void;
+  onToggleWeekday: (weekday: number) => void;
+  onSubmit: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-slate-950/75 backdrop-blur-sm" onClick={onClose} />
+      <div className="fixed inset-x-0 top-10 z-50 mx-auto w-[min(92vw,40rem)]">
+        <div className="panel-surface p-5 sm:p-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm uppercase tracking-[0.22em] text-slate-400">Add Event</p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">Create recurring event</h2>
+              <p className="mt-2 text-sm text-slate-300">
+                Examples: work Mon-Fri from 9AM-5PM, dance practice every Wednesday 6PM-7PM.
+              </p>
+            </div>
+            <button
+              className="rounded-full p-2 text-slate-400 transition hover:bg-white/5 hover:text-white"
+              onClick={onClose}
+              type="button"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="mt-5 grid gap-4">
+            <input
+              className="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-3 text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/20"
+              onChange={(event) => onChange({ title: event.target.value })}
+              placeholder="Event title"
+              value={form.title}
+            />
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="grid gap-2 text-sm text-slate-300">
+                <span>Start date</span>
+                <input
+                  className="rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-3 text-sm text-slate-200 outline-none transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/20"
+                  onChange={(event) => onChange({ startDate: event.target.value })}
+                  type="date"
+                  value={form.startDate}
+                />
+              </label>
+              <label className="grid gap-2 text-sm text-slate-300">
+                <span>End date</span>
+                <input
+                  className="rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-3 text-sm text-slate-200 outline-none transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/20"
+                  onChange={(event) => onChange({ endDate: event.target.value })}
+                  type="date"
+                  value={form.endDate}
+                />
+              </label>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="grid gap-2 text-sm text-slate-300">
+                <span>Start time</span>
+                <input
+                  className="rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-3 text-sm text-slate-200 outline-none transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/20"
+                  disabled={form.allDay}
+                  onChange={(event) => onChange({ startTime: event.target.value })}
+                  type="time"
+                  value={form.startTime}
+                />
+              </label>
+              <label className="grid gap-2 text-sm text-slate-300">
+                <span>End time</span>
+                <input
+                  className="rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-3 text-sm text-slate-200 outline-none transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/20"
+                  disabled={form.allDay}
+                  onChange={(event) => onChange({ endTime: event.target.value })}
+                  type="time"
+                  value={form.endTime}
+                />
+              </label>
+            </div>
+
+            <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-slate-200">
+              <input
+                checked={form.allDay}
+                className="h-4 w-4 accent-cyan-300"
+                onChange={(event) => onChange({ allDay: event.target.checked })}
+                type="checkbox"
+              />
+              All-day event
+            </label>
+
+            <label className="grid gap-2 text-sm text-slate-300">
+              <span>Repeat</span>
+              <select
+                className="rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-3 text-sm text-slate-200 outline-none transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/20"
+                onChange={(event) =>
+                  onChange({ recurrence: event.target.value as EventFormState["recurrence"] })
+                }
+                value={form.recurrence}
+              >
+                <option value="none">Does not repeat</option>
+                <option value="daily">Daily</option>
+                <option value="weekday">Every weekday (Mon-Fri)</option>
+                <option value="weekly">Weekly on selected days</option>
+                <option value="biweekly">Every other week (biweekly)</option>
+                <option value="monthly">Monthly on start date day</option>
+              </select>
+            </label>
+
+            {(form.recurrence === "weekly" || form.recurrence === "biweekly") && (
+              <div className="grid gap-2">
+                <p className="text-sm text-slate-300">Weekdays</p>
+                <div className="flex flex-wrap gap-2">
+                  {weekdayOptions.map((day) => {
+                    const active = form.weekdays.includes(day.value);
+                    return (
+                      <button
+                        key={day.value}
+                        className={`rounded-full px-3 py-2 text-sm font-medium transition ${
+                          active
+                            ? "bg-cyan-300 text-slate-950"
+                            : "border border-white/10 bg-white/5 text-slate-300 hover:bg-white/10"
+                        }`}
+                        onClick={() => onToggleWeekday(day.value)}
+                        type="button"
+                      >
+                        {day.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-slate-300">
+              {form.recurrence === "weekday" && "This event will repeat Monday through Friday."}
+              {form.recurrence === "biweekly" && "This event will repeat every other week on the selected days."}
+              {form.recurrence === "monthly" &&
+                `This event will repeat on day ${new Date(`${form.startDate}T00:00:00`).getDate()} of each month.`}
+              {form.recurrence === "weekly" &&
+                "This event will repeat on the selected weekdays using the same time window."}
+              {form.recurrence === "daily" && "This event will repeat every day using the same time window."}
+              {form.recurrence === "none" && "This will create a one-time event."}
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-white/10"
+                onClick={onClose}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="rounded-full bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={loading}
+                onClick={onSubmit}
+                type="button"
+              >
+                {loading ? "Creating..." : "Create event"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function CalendarPanel({ events }: { events: Event[] }) {
   return (
     <section className="space-y-6">
       <div className="panel-surface overflow-hidden p-4 sm:p-6">
-        <CalendarView />
+        <CalendarView events={events} />
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
@@ -381,10 +633,16 @@ function TodoRow({
 
 function TodoPanel({ mobile = false }: { mobile?: boolean }) {
   const { todos, loading, error, createTodo, deleteTodo, toggleStatus, updateTodo } = useTodos();
+  const { createEvent } = useEvents();
   const [sortMode, setSortMode] = useState<SortMode>("priority");
   const [newTitle, setNewTitle] = useState("");
   const [newPriority, setNewPriority] = useState<Priority>("medium");
   const [newDueAt, setNewDueAt] = useState("");
+  const [newRecurring, setNewRecurring] = useState(false);
+  const [newEventStartTime, setNewEventStartTime] = useState("09:00");
+  const [newEventEndTime, setNewEventEndTime] = useState("10:00");
+  const [newEventRecurrence, setNewEventRecurrence] = useState<EventFormState["recurrence"]>("weekly");
+  const [newEventWeekdays, setNewEventWeekdays] = useState<number[]>([]);
   const [editingTodoId, setEditingTodoId] = useState<string | null>(null);
   const [draft, setDraft] = useState<TodoDraft | null>(null);
 
@@ -421,15 +679,47 @@ function TodoPanel({ mobile = false }: { mobile?: boolean }) {
     const trimmedTitle = newTitle.trim();
     if (!trimmedTitle) return;
 
+    let linkedEventId: string | null = null;
+
+    if (newRecurring) {
+      const baseDate = newDueAt || new Date().toISOString().slice(0, 10);
+      linkedEventId = await createEvent({
+        title: trimmedTitle,
+        start_at: `${baseDate}T${newEventStartTime}:00`,
+        end_at: `${baseDate}T${newEventEndTime}:00`,
+        all_day: false,
+        rrule: buildRRule({
+          title: trimmedTitle,
+          startDate: baseDate,
+          startTime: newEventStartTime,
+          endDate: baseDate,
+          endTime: newEventEndTime,
+          allDay: false,
+          recurrence: newEventRecurrence,
+          weekdays:
+            newEventWeekdays.length > 0
+              ? newEventWeekdays
+              : [new Date(`${baseDate}T00:00:00`).getDay()],
+        }),
+      });
+    }
+
     await createTodo({
       title: trimmedTitle,
       priority: newPriority,
       due_at: newDueAt || null,
+      linked_event_id: linkedEventId,
+      status: linkedEventId ? "scheduled" : undefined,
     });
 
     setNewTitle("");
     setNewPriority("medium");
     setNewDueAt("");
+    setNewRecurring(false);
+    setNewEventStartTime("09:00");
+    setNewEventEndTime("10:00");
+    setNewEventRecurrence("weekly");
+    setNewEventWeekdays([]);
   }
 
   async function handleCreateSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -537,6 +827,86 @@ function TodoPanel({ mobile = false }: { mobile?: boolean }) {
                 Add todo
               </button>
             </div>
+
+            <label className="flex cursor-pointer select-none items-center gap-2.5 text-sm text-slate-700 dark:text-slate-200">
+              <input
+                checked={newRecurring}
+                className="h-4 w-4 accent-cyan-600 dark:accent-cyan-300"
+                onChange={(event) => setNewRecurring(event.target.checked)}
+                type="checkbox"
+              />
+              Schedule as recurring calendar event
+            </label>
+
+            {newRecurring && (
+              <div className="space-y-3 rounded-2xl border border-slate-900/10 bg-slate-50/80 p-3 dark:border-white/10 dark:bg-slate-950/50">
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <label className="grid gap-1">
+                    <span className="text-xs text-slate-500 dark:text-slate-400">Start time</span>
+                    <input
+                      className="rounded-xl border border-slate-900/10 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-cyan-600 dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-200 dark:focus:border-cyan-300"
+                      onChange={(event) => setNewEventStartTime(event.target.value)}
+                      type="time"
+                      value={newEventStartTime}
+                    />
+                  </label>
+                  <label className="grid gap-1">
+                    <span className="text-xs text-slate-500 dark:text-slate-400">End time</span>
+                    <input
+                      className="rounded-xl border border-slate-900/10 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-cyan-600 dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-200 dark:focus:border-cyan-300"
+                      onChange={(event) => setNewEventEndTime(event.target.value)}
+                      type="time"
+                      value={newEventEndTime}
+                    />
+                  </label>
+                </div>
+                <select
+                  className="w-full rounded-xl border border-slate-900/10 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-cyan-600 dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-200 dark:focus:border-cyan-300"
+                  onChange={(event) =>
+                    setNewEventRecurrence(event.target.value as EventFormState["recurrence"])
+                  }
+                  value={newEventRecurrence}
+                >
+                  <option value="daily">Every day</option>
+                  <option value="weekday">Every weekday (Mon–Fri)</option>
+                  <option value="weekly">Weekly on selected days</option>
+                  <option value="biweekly">Every other week (biweekly)</option>
+                  <option value="monthly">Monthly on due date day</option>
+                </select>
+                {(newEventRecurrence === "weekly" || newEventRecurrence === "biweekly") && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {weekdayOptions.map((day) => {
+                      const active = newEventWeekdays.includes(day.value);
+                      return (
+                        <button
+                          key={day.value}
+                          className={`rounded-full px-2.5 py-1 text-xs font-medium transition ${
+                            active
+                              ? "bg-cyan-600 text-white dark:bg-cyan-300 dark:text-slate-950"
+                              : "border border-slate-900/10 bg-white text-slate-600 hover:bg-slate-900/[0.06] dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-300 dark:hover:bg-white/10"
+                          }`}
+                          onClick={() =>
+                            setNewEventWeekdays((prev) =>
+                              active
+                                ? prev.filter((v) => v !== day.value)
+                                : [...prev, day.value].sort((a, b) => a - b)
+                            )
+                          }
+                          type="button"
+                        >
+                          {day.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {!newDueAt && (
+                  <p className="text-xs text-amber-700 dark:text-amber-300">
+                    Tip: set a due date above to anchor the event's start date.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         </form>
 
@@ -619,12 +989,56 @@ function TodoPanel({ mobile = false }: { mobile?: boolean }) {
 
 export default function DashboardPage() {
   const { user, profile, signOut } = useAuth();
+  const { events, createEvent } = useEvents();
   const navigate = useNavigate();
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const [eventComposerOpen, setEventComposerOpen] = useState(false);
+  const [eventSubmitting, setEventSubmitting] = useState(false);
+  const [eventForm, setEventForm] = useState<EventFormState>(getDefaultEventFormState());
+
+  const visibleEvents = useMemo(() => events, [events]);
 
   async function handleLogout() {
     await signOut();
     navigate("/", { replace: true });
+  }
+
+  function resetEventComposer() {
+    setEventForm(getDefaultEventFormState());
+    setEventComposerOpen(false);
+    setEventSubmitting(false);
+  }
+
+  function handleToggleWeekday(weekday: number) {
+    setEventForm((current) => ({
+      ...current,
+      weekdays: current.weekdays.includes(weekday)
+        ? current.weekdays.filter((value) => value !== weekday)
+        : [...current.weekdays, weekday].sort((a, b) => a - b),
+    }));
+  }
+
+  async function handleCreateEvent() {
+    if (!eventForm.title.trim()) return;
+
+    setEventSubmitting(true);
+
+    const startAt = eventForm.allDay
+      ? `${eventForm.startDate}T00:00:00`
+      : toDateTime(eventForm.startDate, eventForm.startTime);
+    const endAt = eventForm.allDay
+      ? `${eventForm.endDate}T23:59:00`
+      : toDateTime(eventForm.endDate, eventForm.endTime);
+
+    await createEvent({
+      title: eventForm.title.trim(),
+      start_at: startAt,
+      end_at: endAt,
+      all_day: eventForm.allDay,
+      rrule: buildRRule(eventForm),
+    });
+
+    resetEventComposer();
   }
 
   return (
@@ -638,7 +1052,7 @@ export default function DashboardPage() {
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] lg:items-start">
-          <CalendarPanel />
+          <CalendarPanel events={visibleEvents} />
           <aside className="hidden lg:block">
             <TodoPanel />
           </aside>
@@ -662,6 +1076,16 @@ export default function DashboardPage() {
           </div>
         </section>
       </main>
+
+      <EventComposer
+        form={eventForm}
+        loading={eventSubmitting}
+        onChange={(patch) => setEventForm((current) => ({ ...current, ...patch }))}
+        onClose={resetEventComposer}
+        onSubmit={() => void handleCreateEvent()}
+        onToggleWeekday={handleToggleWeekday}
+        open={eventComposerOpen}
+      />
 
       <div
         className={`fixed inset-0 z-30 bg-slate-900/40 backdrop-blur-sm transition lg:hidden dark:bg-slate-950/70 ${

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,7 @@ export interface Todo {
 export type RRulePreset =
   | { preset: "daily" }
   | { preset: "weekly"; weekdays: number[] }
+  | { preset: "biweekly"; weekdays: number[] }
   | { preset: "monthly"; day_of_month: number }
   | { preset: "weekday" };
 


### PR DESCRIPTION
- Add EventContext, useEvents hook, and rruleHelpers with expand functions for daily, weekly, biweekly, weekday, and monthly recurrence patterns
- Extend RRulePreset with biweekly variant (fires every other week)
- Wire EventProvider into App and integrate CalendarView with real events
- Add "Schedule as recurring calendar event" sub-form to TodoPanel create flow: checkbox reveals time pickers, recurrence dropdown, and weekday toggles; on submit creates the event then links it to the todo via linked_event_id with status "scheduled"
- Update EventComposer to support biweekly and make Add event button static