### PR TITLE
feat(ai): complete Section 10.1 conversation loop in Edge Function

### DIFF
--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -1,15 +1,6 @@
 // Dayforma AI Assistant — Supabase Edge Function
 // Runtime: Deno (Supabase Edge)
 // Model: claude-sonnet-4-6
-//
-// Responsibilities (expanded in Sprint 2):
-//   1. Verify the caller's Supabase JWT
-//   2. Load conversation history from ai_conversations
-//   3. Call Claude with cached system prompt + tool definitions
-//   4. Execute tool calls against the user's data (with RLS on the user's session)
-//   5. Persist the updated conversation and return the response
-//
-// This file is a scaffold. Sprint 2 issue #22 fleshes out the full tool-use loop.
 
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.40.0";
@@ -27,40 +18,44 @@ Rules:
 - Prefer the user's working hours (9:00–18:00 local) unless told otherwise.
 - Always respond in English.`;
 
-const TOOLS = [
-  // Full tool schemas land in Sprint 2 issue #23.
+const TOOLS: Anthropic.Tool[] = [
+  // Full tool schemas land in the next task (define tool schemas).
   {
     name: "create_event",
     description: "Create a calendar event on the user's calendar.",
     input_schema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         title: { type: "string" },
         start_at: { type: "string", format: "date-time" },
         end_at: { type: "string", format: "date-time" },
         all_day: { type: "boolean" },
-        category_name: { type: "string" }
+        category_name: { type: "string" },
       },
-      required: ["title", "start_at", "end_at"]
-    }
-  }
+      required: ["title", "start_at", "end_at"],
+    },
+  },
 ];
+
+type StoredMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
 
 interface AssistantRequest {
   conversation_id?: string;
   message: string;
 }
 
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
 serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "authorization, content-type",
-        "Access-Control-Allow-Methods": "POST, OPTIONS"
-      }
-    });
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
 
   if (req.method !== "POST") {
@@ -81,40 +76,96 @@ serve(async (req: Request) => {
   }
 
   const supabase = createClient(supabaseUrl, supabaseAnon, {
-    global: { headers: { Authorization: authHeader } }
+    global: { headers: { Authorization: authHeader } },
   });
 
+  // ── 1. Verify JWT ────────────────────────────────────────────────────────────
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError || !userData?.user) {
     return new Response("Unauthorized", { status: 401 });
   }
 
   const body = (await req.json()) as AssistantRequest;
+  if (!body.message?.trim()) {
+    return new Response("message is required", { status: 400 });
+  }
 
+  // ── 2. Load conversation history ─────────────────────────────────────────────
+  let conversationId: string | null = body.conversation_id ?? null;
+  let history: StoredMessage[] = [];
+
+  if (conversationId) {
+    const { data: conv } = await supabase
+      .from("ai_conversations")
+      .select("messages")
+      .eq("id", conversationId)
+      .single();
+    if (conv?.messages) {
+      history = conv.messages as StoredMessage[];
+    }
+  }
+
+  // ── 3. Call Claude with cached system prompt + conversation history ───────────
   const anthropic = new Anthropic({ apiKey: anthropicKey });
 
-  const response = await anthropic.messages.create({
+  const claudeResponse = await anthropic.messages.create({
     model: CLAUDE_MODEL,
     max_tokens: 1024,
     system: [
       {
         type: "text",
         text: SYSTEM_PROMPT,
-        cache_control: { type: "ephemeral" }
-      }
+        cache_control: { type: "ephemeral" },
+      },
     ],
     tools: TOOLS,
-    messages: [{ role: "user", content: body.message }]
+    messages: [
+      ...history,
+      { role: "user", content: body.message },
+    ],
   });
 
-  // TODO (Sprint 2 issue #22+): loop on tool_use blocks, execute DB mutations,
-  // persist to ai_conversations, return the final assistant message.
+  // Extract text from response (tool execution loop added in next task)
+  const assistantText = claudeResponse.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
 
-  return new Response(JSON.stringify({ ok: true, response }), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/json",
-      "Access-Control-Allow-Origin": "*"
+  // ── 4. Persist updated conversation ──────────────────────────────────────────
+  const updatedMessages: StoredMessage[] = [
+    ...history,
+    { role: "user", content: body.message },
+    { role: "assistant", content: assistantText },
+  ];
+
+  if (conversationId) {
+    await supabase
+      .from("ai_conversations")
+      .update({ messages: updatedMessages })
+      .eq("id", conversationId);
+  } else {
+    const { data: newConv } = await supabase
+      .from("ai_conversations")
+      .insert({
+        user_id: userData.user.id,
+        title: body.message.slice(0, 80),
+        messages: updatedMessages,
+      })
+      .select("id")
+      .single();
+    conversationId = newConv?.id ?? null;
+  }
+
+  // ── 5. Return response ────────────────────────────────────────────────────────
+  return new Response(
+    JSON.stringify({
+      conversation_id: conversationId,
+      message: assistantText,
+      stop_reason: claudeResponse.stop_reason,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
     }
-  });
+  );
 });


### PR DESCRIPTION
## Summary
- Load existing conversation history from `ai_conversations` before each Claude call so the model has full context across turns
- Pass full message history + new user message to Claude instead of just the single message
- Upsert conversation back to DB after each turn; creates a new row (titled from the first message) when no `conversation_id` is supplied
- Return `conversation_id` in every response so the client can thread subsequent turns

## Test plan
- [ ] Send a message with no `conversation_id` — verify a new row is created in `ai_conversations` and the ID is returned
- [ ] Send a follow-up message with the returned `conversation_id` — verify Claude receives the prior context and the row is updated
- [ ] Send a request without a valid JWT — verify 401 is returned
- [ ] Verify `stop_reason` is included in the response