### PR TITLE
feat: NL quick-add intercept + AI tool execution loop

### DIFF
--- a/src/components/ai/AIAssistant.tsx
+++ b/src/components/ai/AIAssistant.tsx
@@ -7,11 +7,13 @@ import {
 } from "react";
 import { Bot, RotateCcw, Send, X } from "lucide-react";
 import { useAIAssistant, type ChatMessage } from "../../hooks/useAIAssistant";
+import { useEvents } from "../../hooks/useEvents";
 import ConversationBubble from "./ConversationBubble";
 
 interface Props {
   open: boolean;
   onClose: () => void;
+  queuedMessage?: string;
 }
 
 function ThinkingBubble() {
@@ -153,8 +155,17 @@ function PanelContent({ messages, loading, error, onSend, onClear, onClose }: Pa
   );
 }
 
-export default function AIAssistant({ open, onClose }: Props) {
-  const { messages, loading, error, send, clear } = useAIAssistant();
+export default function AIAssistant({ open, onClose, queuedMessage }: Props) {
+  const { refreshEvents } = useEvents();
+  const { messages, loading, error, send, clear } = useAIAssistant(refreshEvents);
+
+  const sentRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (open && queuedMessage && queuedMessage !== sentRef.current) {
+      sentRef.current = queuedMessage;
+      void send(queuedMessage);
+    }
+  }, [open, queuedMessage, send]);
 
   const handleKeyDown = useCallback(
     (e: globalThis.KeyboardEvent) => {

--- a/src/contexts/EventContext.tsx
+++ b/src/contexts/EventContext.tsx
@@ -88,6 +88,7 @@ export interface EventContextValue {
   createEvent: (input: CreateEventInput) => Promise<string | null>;
   updateEvent: (id: string, input: UpdateEventInput) => Promise<void>;
   deleteEvent: (id: string) => Promise<void>;
+  refreshEvents: () => Promise<void>;
 }
 
 export const EventContext = createContext<EventContextValue | null>(null);
@@ -232,6 +233,18 @@ export function EventProvider({ children }: { children: ReactNode }) {
     []
   );
 
+  const refreshEvents = useCallback(async () => {
+    if (!user?.id) return;
+    const { data, error } = await supabase
+      .from("events")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("start_at", { ascending: true });
+    if (!error) {
+      dispatch({ type: "SET_EVENTS", payload: (data ?? []) as Event[] });
+    }
+  }, [user?.id]);
+
   const deleteEvent = useCallback(
     async (id: string): Promise<void> => {
       const existing = eventsRef.current.find((e) => e.id === id);
@@ -260,8 +273,9 @@ export function EventProvider({ children }: { children: ReactNode }) {
       createEvent,
       updateEvent,
       deleteEvent,
+      refreshEvents,
     }),
-    [state.events, state.loading, state.error, createEvent, updateEvent, deleteEvent]
+    [state.events, state.loading, state.error, createEvent, updateEvent, deleteEvent, refreshEvents]
   );
 
   return <EventContext.Provider value={value}>{children}</EventContext.Provider>;

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -15,11 +15,13 @@ interface AIResponse {
 
 const MAX_DISPLAY = 40; // 20 turns × 2 messages
 
-export function useAIAssistant() {
+export function useAIAssistant(onResponse?: () => void) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const conversationIdRef = useRef<string | null>(null);
+  const onResponseRef = useRef(onResponse);
+  onResponseRef.current = onResponse;
 
   const send = useCallback(
     async (text: string) => {
@@ -41,6 +43,7 @@ export function useAIAssistant() {
           body: {
             conversation_id: conversationIdRef.current ?? undefined,
             message: trimmed,
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           },
         }
       );
@@ -62,6 +65,7 @@ export function useAIAssistant() {
         content: data.message,
       };
       setMessages((prev) => [...prev, assistantMsg].slice(-MAX_DISPLAY));
+      onResponseRef.current?.();
     },
     [loading]
   );

--- a/src/lib/nlDetect.ts
+++ b/src/lib/nlDetect.ts
@@ -1,0 +1,9 @@
+const TEMPORAL = /\b(today|tonight|tomorrow|yesterday|monday|tuesday|wednesday|thursday|friday|saturday|sunday|next week|this week|next month|this month|in \d+ (day|hour|minute|week|month)s?|at \d{1,2}(:\d{2})?\s*(am|pm)|(\d{1,2})(am|pm)\b|morning|afternoon|evening|noon|midnight|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\b/i;
+
+const EVENT_NOUNS = /\b(meeting|appointment|call|lunch|dinner|breakfast|brunch|interview|class|session|gym|dentist|doctor|event|reminder|standup|sync|review|demo|presentation|conference|workshop|seminar|birthday|anniversary|deadline|flight|trip|vacation|party|wedding|pickup|dropoff|pickup|coffee|catchup|check-?in|one-?on-?one|1:1)\b/i;
+
+export function looksLikeNL(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < 10) return false;
+  return TEMPORAL.test(trimmed) || EVENT_NOUNS.test(trimmed);
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { format, isThisWeek, isToday, isTomorrow, parseISO } from "date-fns";
 import { toast } from "sonner";
 import { Calendar, Check, LogOut, Pencil, Settings, Sparkles, Trash2, X } from "lucide-react";
 import AIAssistant from "../components/ai/AIAssistant";
+import { looksLikeNL } from "../lib/nlDetect";
 import { useAuth } from "../hooks/useAuth";
 import { useCategories } from "../hooks/useCategories";
 import { useEvents } from "../hooks/useEvents";
@@ -804,7 +805,7 @@ function TodoRow({
   );
 }
 
-function TodoPanel({ mobile = false }: { mobile?: boolean }) {
+function TodoPanel({ mobile = false, onRouteToAI }: { mobile?: boolean; onRouteToAI?: (msg: string) => void }) {
   const { todos, loading, error, createTodo, deleteTodo, toggleStatus, updateTodo } = useTodos();
   const { events, createEvent, updateEvent, deleteEvent } = useEvents();
   const [sortMode, setSortMode] = useState<SortMode>("priority");
@@ -851,6 +852,12 @@ function TodoPanel({ mobile = false }: { mobile?: boolean }) {
   async function handleCreateTodo() {
     const trimmedTitle = newTitle.trim();
     if (!trimmedTitle) return;
+
+    if (looksLikeNL(trimmedTitle) && onRouteToAI) {
+      setNewTitle("");
+      onRouteToAI(trimmedTitle);
+      return;
+    }
 
     let linkedEventId: string | null = null;
 
@@ -1021,12 +1028,19 @@ function TodoPanel({ mobile = false }: { mobile?: boolean }) {
           onSubmit={handleCreateSubmit}
         >
           <div className="grid gap-3">
-            <input
-              className="w-full rounded-2xl border border-slate-900/10 bg-white px-3 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 hover:border-slate-900/20 focus:border-cyan-600 focus:ring-2 focus:ring-cyan-500/30 dark:border-white/10 dark:bg-slate-950/70 dark:text-white dark:placeholder:text-slate-500 dark:hover:border-white/20 dark:focus:border-cyan-300 dark:focus:ring-cyan-300/20"
-              onChange={(event) => setNewTitle(event.target.value)}
-              placeholder="Add a todo title"
-              value={newTitle}
-            />
+            <div>
+              <input
+                className="w-full rounded-2xl border border-slate-900/10 bg-white px-3 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 hover:border-slate-900/20 focus:border-cyan-600 focus:ring-2 focus:ring-cyan-500/30 dark:border-white/10 dark:bg-slate-950/70 dark:text-white dark:placeholder:text-slate-500 dark:hover:border-white/20 dark:focus:border-cyan-300 dark:focus:ring-cyan-300/20"
+                onChange={(event) => setNewTitle(event.target.value)}
+                placeholder="Add a todo title"
+                value={newTitle}
+              />
+              {onRouteToAI && looksLikeNL(newTitle) && (
+                <p className="mt-1.5 px-1 text-xs text-violet-500 dark:text-violet-400">
+                  ✨ Looks like an event — press Enter to send to AI
+                </p>
+              )}
+            </div>
             <div className="grid gap-3 sm:grid-cols-3">
               <select
                 className="w-full cursor-pointer rounded-2xl border border-slate-900/10 bg-white px-3 py-3 text-sm text-slate-700 outline-none transition hover:border-slate-900/20 focus:border-cyan-600 focus:ring-2 focus:ring-cyan-500/30 dark:border-white/10 dark:bg-slate-950/70 dark:text-slate-200 dark:hover:border-white/20 dark:focus:border-cyan-300 dark:focus:ring-cyan-300/20"
@@ -1217,6 +1231,12 @@ export default function DashboardPage() {
   const navigate = useNavigate();
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
+  const [aiQueuedMessage, setAiQueuedMessage] = useState<string | undefined>();
+
+  function openAIWithMessage(msg: string) {
+    setAiQueuedMessage(msg);
+    setAiPanelOpen(true);
+  }
   const [eventComposerOpen, setEventComposerOpen] = useState(false);
   const [eventSubmitting, setEventSubmitting] = useState(false);
   const [eventForm, setEventForm] = useState<EventFormState>(getDefaultEventFormState());
@@ -1389,7 +1409,7 @@ export default function DashboardPage() {
             onAddEvent={handleAddEvent}
           />
           <aside className="hidden lg:block">
-            <TodoPanel />
+            <TodoPanel onRouteToAI={openAIWithMessage} />
           </aside>
         </div>
 
@@ -1458,7 +1478,7 @@ export default function DashboardPage() {
               type="button"
             />
           </div>
-          <TodoPanel mobile />
+          <TodoPanel mobile onRouteToAI={openAIWithMessage} />
         </div>
       </div>
 
@@ -1475,7 +1495,7 @@ export default function DashboardPage() {
         Schedule with AI
       </button>
 
-      <AIAssistant open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      <AIAssistant open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} queuedMessage={aiQueuedMessage} />
     </div>
   );
 }

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -6,6 +6,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.40.0";
 import { createClient } from "jsr:@supabase/supabase-js@^2.57.4";
 import { TOOLS } from "./tools.ts";
+import { executeTool } from "./toolHandlers.ts";
 
 const CLAUDE_MODEL = "claude-sonnet-4-6";
 const MAX_STORED_MESSAGES = 50;
@@ -28,11 +29,12 @@ type StoredMessage = {
 interface AssistantRequest {
   conversation_id?: string;
   message: string;
+  timezone?: string;
 }
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
@@ -88,31 +90,81 @@ serve(async (req: Request) => {
     }
   }
 
-  // ── 3. Call Claude with cached system prompt + conversation history ───────────
+  // ── 3. Call Claude — agentic loop (max 5 iterations) ────────────────────────
   const anthropic = new Anthropic({ apiKey: anthropicKey });
 
-  const claudeResponse = await anthropic.messages.create({
-    model: CLAUDE_MODEL,
-    max_tokens: 1024,
-    system: [
-      {
-        type: "text",
-        text: SYSTEM_PROMPT,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
-    tools: TOOLS,
-    messages: [
-      ...history,
-      { role: "user", content: body.message },
-    ],
-  });
+  const tz = body.timezone ?? "UTC";
+  const nowDate = new Date();
 
-  // Extract text from response (tool execution loop added in next task)
-  const assistantText = claudeResponse.content
-    .filter((block): block is Anthropic.TextBlock => block.type === "text")
-    .map((block) => block.text)
-    .join("\n");
+  // Compute UTC offset for the user's timezone (accounts for DST)
+  const localMs = new Date(nowDate.toLocaleString("en-US", { timeZone: tz })).getTime();
+  const utcMs = new Date(nowDate.toLocaleString("en-US", { timeZone: "UTC" })).getTime();
+  const diffMins = Math.round((localMs - utcMs) / 60000);
+  const sign = diffMins >= 0 ? "+" : "-";
+  const absMins = Math.abs(diffMins);
+  const tzOffset = `${sign}${String(Math.floor(absMins / 60)).padStart(2, "0")}:${String(absMins % 60).padStart(2, "0")}`;
+
+  const nowLocal = nowDate.toLocaleString("en-US", { timeZone: tz, hour12: false });
+
+  const systemBlocks = [
+    {
+      type: "text" as const,
+      text: SYSTEM_PROMPT,
+      cache_control: { type: "ephemeral" as const },
+    },
+    {
+      type: "text" as const,
+      text: `Current date/time: ${nowLocal} (${tz}, UTC${tzOffset}). Use this as the reference for all relative dates like "today", "tomorrow", "next Monday". IMPORTANT: always include the UTC offset in every datetime string you produce, e.g. "2026-05-14T15:00:00${tzOffset}". Never emit a bare datetime without an offset.`,
+    },
+  ];
+
+  type MessageParam = Anthropic.MessageParam;
+  let messages: MessageParam[] = [
+    ...history,
+    { role: "user", content: body.message },
+  ];
+
+  let assistantText = "";
+  const MAX_ITERATIONS = 5;
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const response = await anthropic.messages.create({
+      model: CLAUDE_MODEL,
+      max_tokens: 1024,
+      system: systemBlocks,
+      tools: TOOLS,
+      messages,
+    });
+
+    if (response.stop_reason === "tool_use") {
+      const toolUseBlocks = response.content.filter(
+        (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+      );
+
+      messages = [...messages, { role: "assistant", content: response.content }];
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
+        toolUseBlocks.map(async (block) => {
+          const result = await executeTool(block, supabase, userData.user.id);
+          return {
+            type: "tool_result" as const,
+            tool_use_id: block.id,
+            content: JSON.stringify(result),
+          };
+        })
+      );
+
+      messages = [...messages, { role: "user", content: toolResults }];
+      continue;
+    }
+
+    // end_turn or max_tokens — extract final text and stop
+    assistantText = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    break;
+  }
 
   // ── 4. Persist updated conversation (trimmed to last 50 messages) ─────────────
   const updatedMessages: StoredMessage[] = [
@@ -144,7 +196,7 @@ serve(async (req: Request) => {
     JSON.stringify({
       conversation_id: conversationId,
       message: assistantText,
-      stop_reason: claudeResponse.stop_reason,
+      stop_reason: "end_turn",
     }),
     {
       status: 200,

--- a/supabase/functions/ai-assistant/toolHandlers.ts
+++ b/supabase/functions/ai-assistant/toolHandlers.ts
@@ -1,0 +1,191 @@
+// Tool execution handlers for the Dayforma AI assistant.
+// Each handler validates input via Zod, runs a DB operation, and returns a
+// plain object that gets serialised into a tool_result message for Claude.
+
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@^2.57.4";
+import type Anthropic from "npm:@anthropic-ai/sdk@^0.40.0";
+import {
+  CreateEventSchema,
+  CreateTodoSchema,
+  DeleteEventSchema,
+  FindFreeTimeSchema,
+  ListEventsSchema,
+  SummarizeWeekSchema,
+  UpdateEventSchema,
+} from "./tools.ts";
+
+type ToolUseBlock = Anthropic.ToolUseBlock;
+
+export async function executeTool(
+  block: ToolUseBlock,
+  supabase: SupabaseClient,
+  userId: string
+): Promise<unknown> {
+  switch (block.name) {
+    case "create_event": {
+      const input = CreateEventSchema.parse(block.input);
+
+      let categoryId: string | null = null;
+      if (input.category_name) {
+        const { data: cat } = await supabase
+          .from("categories")
+          .select("id")
+          .eq("user_id", userId)
+          .ilike("name", input.category_name)
+          .maybeSingle();
+        categoryId = cat?.id ?? null;
+      }
+
+      const { data, error } = await supabase
+        .from("events")
+        .insert({
+          user_id: userId,
+          title: input.title,
+          start_at: input.start_at,
+          end_at: input.end_at,
+          all_day: input.all_day ?? false,
+          description: input.description ?? null,
+          category_id: categoryId,
+          created_by_ai: true,
+        })
+        .select("id, title, start_at, end_at")
+        .single();
+
+      if (error) return { error: error.message };
+      return { success: true, event: data };
+    }
+
+    case "update_event": {
+      const input = UpdateEventSchema.parse(block.input);
+      const updates: Record<string, unknown> = {};
+      if (input.title !== undefined) updates.title = input.title;
+      if (input.start_at !== undefined) updates.start_at = input.start_at;
+      if (input.end_at !== undefined) updates.end_at = input.end_at;
+      if (input.all_day !== undefined) updates.all_day = input.all_day;
+      if (input.description !== undefined) updates.description = input.description;
+
+      const { error } = await supabase
+        .from("events")
+        .update(updates)
+        .eq("id", input.id)
+        .eq("user_id", userId);
+
+      if (error) return { error: error.message };
+      return { success: true };
+    }
+
+    case "delete_event": {
+      const input = DeleteEventSchema.parse(block.input);
+      const { error } = await supabase
+        .from("events")
+        .delete()
+        .eq("id", input.id)
+        .eq("user_id", userId);
+
+      if (error) return { error: error.message };
+      return { success: true };
+    }
+
+    case "create_todo": {
+      const input = CreateTodoSchema.parse(block.input);
+      const { data, error } = await supabase
+        .from("todos")
+        .insert({
+          user_id: userId,
+          title: input.title,
+          priority: input.priority ?? "medium",
+          due_at: input.due_at ?? null,
+          description: input.description ?? null,
+          status: "pending",
+          created_by_ai: true,
+        })
+        .select("id, title")
+        .single();
+
+      if (error) return { error: error.message };
+      return { success: true, todo: data };
+    }
+
+    case "find_free_time": {
+      const input = FindFreeTimeSchema.parse(block.input);
+      const afterTime = input.after_time ?? "09:00";
+      const beforeTime = input.before_time ?? "18:00";
+      const dayStart = `${input.date}T${afterTime}:00`;
+      const dayEnd = `${input.date}T${beforeTime}:00`;
+
+      const { data: events } = await supabase
+        .from("events")
+        .select("start_at, end_at, title")
+        .eq("user_id", userId)
+        .gte("start_at", dayStart)
+        .lt("end_at", dayEnd)
+        .order("start_at");
+
+      const durationMs = input.duration_minutes * 60 * 1000;
+      const slots: Array<{ start: string; end: string }> = [];
+      let cursor = new Date(dayStart);
+      const workEnd = new Date(dayEnd);
+
+      for (const ev of events ?? []) {
+        const evStart = new Date(ev.start_at);
+        if (evStart.getTime() - cursor.getTime() >= durationMs) {
+          slots.push({
+            start: cursor.toISOString(),
+            end: new Date(cursor.getTime() + durationMs).toISOString(),
+          });
+        }
+        const evEnd = new Date(ev.end_at);
+        if (evEnd > cursor) cursor = evEnd;
+      }
+
+      if (workEnd.getTime() - cursor.getTime() >= durationMs) {
+        slots.push({
+          start: cursor.toISOString(),
+          end: new Date(cursor.getTime() + durationMs).toISOString(),
+        });
+      }
+
+      return { date: input.date, duration_minutes: input.duration_minutes, free_slots: slots };
+    }
+
+    case "list_events": {
+      const input = ListEventsSchema.parse(block.input);
+      const { data, error } = await supabase
+        .from("events")
+        .select("id, title, start_at, end_at, all_day, description")
+        .eq("user_id", userId)
+        .gte("start_at", `${input.start_date}T00:00:00`)
+        .lte("start_at", `${input.end_date}T23:59:59`)
+        .order("start_at");
+
+      if (error) return { error: error.message };
+      return { events: data ?? [] };
+    }
+
+    case "summarize_week": {
+      const input = SummarizeWeekSchema.parse(block.input);
+      const weekStart = new Date(`${input.week_start}T00:00:00`);
+      const weekEnd = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+      const [{ data: events }, { data: todos }] = await Promise.all([
+        supabase
+          .from("events")
+          .select("title, start_at, end_at, all_day")
+          .eq("user_id", userId)
+          .gte("start_at", weekStart.toISOString())
+          .lt("start_at", weekEnd.toISOString())
+          .order("start_at"),
+        supabase
+          .from("todos")
+          .select("title, priority, status, due_at")
+          .eq("user_id", userId)
+          .in("status", ["pending", "scheduled"]),
+      ]);
+
+      return { week_start: input.week_start, events: events ?? [], todos: todos ?? [] };
+    }
+
+    default:
+      return { error: `Unknown tool: ${block.name}` };
+  }
+}


### PR DESCRIPTION
## Summary

- **Edge Function tool loop** — Claude now executes tools in a 5-iteration agentic loop; all 7 tools implemented (create/update/delete event, create todo, find free time, list events, summarize week)
- **CORS fix** — added `x-client-info` and `apikey` to allowed headers so browser requests reach the function
- **Timezone fix** — inject current date/time and UTC offset into every request so relative times like "tomorrow at 3pm" are stored with the correct offset
- **NL intercept** — quick-add input detects event-like language (temporal words, event nouns) and routes to the AI panel with the text pre-sent
- **Auto-refresh** — calendar re-fetches events after each AI response so AI-created events appear without a page reload

## Test plan

- [ ] Type "dentist tomorrow at 3pm" in quick-add → hint appears → Enter routes to AI panel → event created at correct local time on calendar
- [ ] Type "Buy groceries" → no intercept, plain todo created normally
- [ ] Type directly in AI panel: "Schedule a 1-hour gym session next Monday at 7am" → event appears on calendar immediately
- [ ] Ask "What's on my calendar this week?" → Claude lists events
- [ ] Ask "Find me a free 30-minute slot tomorrow" → Claude returns available times