### PR TITLE
feat: NL intercept, drag-drop scheduling, and category inference

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -6,12 +6,11 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import interactionPlugin from "@fullcalendar/interaction";
-import type { DateClickArg } from "@fullcalendar/interaction";
+import type { DateClickArg, DropArg } from "@fullcalendar/interaction";
 import type {
   DatesSetArg,
   EventClickArg,
   EventMountArg,
-  DropArg,
 } from "@fullcalendar/core";
 import { expandRecurringEvents } from "../../lib/rruleHelpers";
 import type { Event } from "../../types";

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1321,7 +1321,7 @@ export default function DashboardPage() {
       const todo = todos.find((t) => t.id === todoId);
       if (!todo) return;
 
-      if (shiftKey) {
+      if (!shiftKey) {
         const pad = (n: number) => String(n).padStart(2, "0");
         const toLocalISO = (d: Date) =>
           `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:00`;


### PR DESCRIPTION
## Summary
- NL quick-add intercept routes natural-language todo titles to the AI assistant tool execution loop
- Drag-and-drop from todo list to calendar creates a 1-hour event directly; Shift+drop routes through Claude for AI-chosen duration
- Category inference Edge Function (`infer-todo`) auto-classifies new todos by priority and category using a single Claude call; result patches the todo ~1–2s after save
- Category badge displayed on todo items; category dropdown added to creation form and inline edit
- Calendar events created via drag-drop inherit the todo's category color
- Fix: `DropArg` moved to correct `@fullcalendar/interaction` import (build error)

## Test plan
- [ ] Type a natural-language todo title (e.g. "remind me to call the dentist tomorrow") → AI intercept prompt appears
- [ ] Type a plain title (e.g. "Buy groceries") → saves directly, priority/category update within ~2s
- [ ] Drag a todo onto the calendar → 1-hour event created immediately
- [ ] Shift+drag a todo onto the calendar → AI panel opens with scheduling message
- [ ] Category badge appears on todo items after inference
- [ ] Category dropdown works in creation form and edit mode
- [ ] `npm run typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)