### PR TITLE
feat: 30-second undo toast for AI-created events and todos

### DIFF
--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -1,5 +1,10 @@
 import { useCallback, useRef, useState } from "react";
 import { supabase } from "../lib/supabase";
+import { applyWithUndo } from "../lib/applyWithUndo";
+import type { MutationRecord } from "../lib/applyWithUndo";
+import { useEvents } from "./useEvents";
+import { useTodos } from "./useTodos";
+import type { CreateEventInput, UpdateEventInput } from "../contexts/EventContext";
 
 export interface ChatMessage {
   id: string;
@@ -11,6 +16,7 @@ interface AIResponse {
   conversation_id: string;
   message: string;
   stop_reason: string;
+  mutations?: MutationRecord[];
 }
 
 const MAX_DISPLAY = 40; // 20 turns × 2 messages
@@ -22,6 +28,9 @@ export function useAIAssistant(onResponse?: () => void) {
   const conversationIdRef = useRef<string | null>(null);
   const onResponseRef = useRef(onResponse);
   onResponseRef.current = onResponse;
+
+  const { createEvent, updateEvent, deleteEvent } = useEvents();
+  const { deleteTodo } = useTodos();
 
   const send = useCallback(
     async (text: string) => {
@@ -59,6 +68,18 @@ export function useAIAssistant(onResponse?: () => void) {
         conversationIdRef.current = data.conversation_id;
       }
 
+      for (const mut of data.mutations ?? []) {
+        if (mut.type === "create_event") {
+          applyWithUndo("Event created", () => deleteEvent(mut.id));
+        } else if (mut.type === "update_event") {
+          applyWithUndo("Event updated", () => updateEvent(mut.id, mut.snapshot as UpdateEventInput));
+        } else if (mut.type === "delete_event") {
+          applyWithUndo("Event deleted", () => createEvent(mut.snapshot as CreateEventInput));
+        } else if (mut.type === "create_todo") {
+          applyWithUndo("Todo created", () => deleteTodo(mut.id));
+        }
+      }
+
       const assistantMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: "assistant",
@@ -67,7 +88,7 @@ export function useAIAssistant(onResponse?: () => void) {
       setMessages((prev) => [...prev, assistantMsg].slice(-MAX_DISPLAY));
       onResponseRef.current?.();
     },
-    [loading]
+    [loading, createEvent, updateEvent, deleteEvent, deleteTodo]
   );
 
   const clear = useCallback(() => {

--- a/src/lib/applyWithUndo.ts
+++ b/src/lib/applyWithUndo.ts
@@ -1,0 +1,19 @@
+import { toast } from "sonner";
+
+export interface MutationRecord {
+  type: "create_event" | "update_event" | "delete_event" | "create_todo";
+  id: string;
+  snapshot: Record<string, unknown> | null;
+}
+
+const UNDO_TIMEOUT_MS = 30_000;
+
+export function applyWithUndo(label: string, undoFn: () => Promise<void>): void {
+  toast(label, {
+    duration: UNDO_TIMEOUT_MS,
+    action: {
+      label: "Undo",
+      onClick: () => void undoFn(),
+    },
+  });
+}

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -7,6 +7,7 @@ import Anthropic from "npm:@anthropic-ai/sdk@^0.40.0";
 import { createClient } from "jsr:@supabase/supabase-js@^2.57.4";
 import { TOOLS } from "./tools.ts";
 import { executeTool } from "./toolHandlers.ts";
+import type { MutationRecord } from "./toolHandlers.ts";
 
 const CLAUDE_MODEL = "claude-sonnet-4-6";
 const MAX_STORED_MESSAGES = 50;
@@ -126,6 +127,7 @@ serve(async (req: Request) => {
 
   let assistantText = "";
   const MAX_ITERATIONS = 5;
+  const mutations: MutationRecord[] = [];
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
     const response = await anthropic.messages.create({
@@ -146,6 +148,7 @@ serve(async (req: Request) => {
       const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
         toolUseBlocks.map(async (block) => {
           const result = await executeTool(block, supabase, userData.user.id);
+          if (result.mutation) mutations.push(result.mutation as MutationRecord);
           return {
             type: "tool_result" as const,
             tool_use_id: block.id,
@@ -197,6 +200,7 @@ serve(async (req: Request) => {
       conversation_id: conversationId,
       message: assistantText,
       stop_reason: "end_turn",
+      mutations,
     }),
     {
       status: 200,

--- a/supabase/functions/ai-assistant/toolHandlers.ts
+++ b/supabase/functions/ai-assistant/toolHandlers.ts
@@ -16,11 +16,17 @@ import {
 
 type ToolUseBlock = Anthropic.ToolUseBlock;
 
+export interface MutationRecord {
+  type: "create_event" | "update_event" | "delete_event" | "create_todo";
+  id: string;
+  snapshot: Record<string, unknown> | null;
+}
+
 export async function executeTool(
   block: ToolUseBlock,
   supabase: SupabaseClient,
   userId: string
-): Promise<unknown> {
+): Promise<Record<string, unknown>> {
   switch (block.name) {
     case "create_event": {
       const input = CreateEventSchema.parse(block.input);
@@ -52,11 +58,23 @@ export async function executeTool(
         .single();
 
       if (error) return { error: error.message };
-      return { success: true, event: data };
+      return {
+        success: true,
+        event: data,
+        mutation: { type: "create_event", id: data.id, snapshot: null } satisfies MutationRecord,
+      };
     }
 
     case "update_event": {
       const input = UpdateEventSchema.parse(block.input);
+
+      const { data: existing } = await supabase
+        .from("events")
+        .select("title, start_at, end_at, all_day, description, category_id, rrule, reminder_offset_minutes")
+        .eq("id", input.id)
+        .eq("user_id", userId)
+        .single();
+
       const updates: Record<string, unknown> = {};
       if (input.title !== undefined) updates.title = input.title;
       if (input.start_at !== undefined) updates.start_at = input.start_at;
@@ -71,11 +89,22 @@ export async function executeTool(
         .eq("user_id", userId);
 
       if (error) return { error: error.message };
-      return { success: true };
+      return {
+        success: true,
+        mutation: { type: "update_event", id: input.id, snapshot: existing ?? null } satisfies MutationRecord,
+      };
     }
 
     case "delete_event": {
       const input = DeleteEventSchema.parse(block.input);
+
+      const { data: existing } = await supabase
+        .from("events")
+        .select("title, start_at, end_at, all_day, description, category_id, rrule, reminder_offset_minutes")
+        .eq("id", input.id)
+        .eq("user_id", userId)
+        .single();
+
       const { error } = await supabase
         .from("events")
         .delete()
@@ -83,7 +112,10 @@ export async function executeTool(
         .eq("user_id", userId);
 
       if (error) return { error: error.message };
-      return { success: true };
+      return {
+        success: true,
+        mutation: { type: "delete_event", id: input.id, snapshot: existing ?? null } satisfies MutationRecord,
+      };
     }
 
     case "create_todo": {
@@ -103,7 +135,11 @@ export async function executeTool(
         .single();
 
       if (error) return { error: error.message };
-      return { success: true, todo: data };
+      return {
+        success: true,
+        todo: data,
+        mutation: { type: "create_todo", id: data.id, snapshot: null } satisfies MutationRecord,
+      };
     }
 
     case "find_free_time": {


### PR DESCRIPTION
## Summary
- AI mutations (create/update/delete event or todo) now return a `mutations` array from the Edge Function
- `toolHandlers.ts` captures snapshots before `update_event` and `delete_event` so the inverse operation has the data it needs
- New `applyWithUndo` helper fires a Sonner toast with a 30-second timer and an Undo action button
- `useAIAssistant` processes the mutations array after each response and fires one toast per mutation

## Test plan
- [ ] Tell the AI to create an event → undo toast appears → clicking Undo removes it
- [ ] Tell the AI to update an event → undo toast appears → clicking Undo restores original values
- [ ] Tell the AI to delete an event → undo toast appears → clicking Undo re-creates it
- [ ] Tell the AI to create a todo → undo toast appears → clicking Undo removes it
- [ ] Let a toast expire → change persists with no error
- [ ] Multiple mutations in one message → one toast per mutation with independent timers