### PR TITLE
fix: add applyWithUndo helper and wire undo toasts in useAIAssistant

### DIFF
--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -1,5 +1,10 @@
 import { useCallback, useRef, useState } from "react";
 import { supabase } from "../lib/supabase";
+import { applyWithUndo } from "../lib/applyWithUndo";
+import type { MutationRecord } from "../lib/applyWithUndo";
+import { useEvents } from "./useEvents";
+import { useTodos } from "./useTodos";
+import type { CreateEventInput, UpdateEventInput } from "../contexts/EventContext";
 
 export interface ChatMessage {
   id: string;
@@ -11,6 +16,7 @@ interface AIResponse {
   conversation_id: string;
   message: string;
   stop_reason: string;
+  mutations?: MutationRecord[];
 }
 
 const MAX_DISPLAY = 40; // 20 turns × 2 messages
@@ -22,6 +28,9 @@ export function useAIAssistant(onResponse?: () => void) {
   const conversationIdRef = useRef<string | null>(null);
   const onResponseRef = useRef(onResponse);
   onResponseRef.current = onResponse;
+
+  const { createEvent, updateEvent, deleteEvent } = useEvents();
+  const { deleteTodo } = useTodos();
 
   const send = useCallback(
     async (text: string) => {
@@ -59,6 +68,18 @@ export function useAIAssistant(onResponse?: () => void) {
         conversationIdRef.current = data.conversation_id;
       }
 
+      for (const mut of data.mutations ?? []) {
+        if (mut.type === "create_event") {
+          applyWithUndo("Event created", () => deleteEvent(mut.id));
+        } else if (mut.type === "update_event") {
+          applyWithUndo("Event updated", () => updateEvent(mut.id, mut.snapshot as UpdateEventInput));
+        } else if (mut.type === "delete_event") {
+          applyWithUndo("Event deleted", async () => { await createEvent(mut.snapshot as unknown as CreateEventInput); });
+        } else if (mut.type === "create_todo") {
+          applyWithUndo("Todo created", () => deleteTodo(mut.id));
+        }
+      }
+
       const assistantMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: "assistant",
@@ -67,7 +88,7 @@ export function useAIAssistant(onResponse?: () => void) {
       setMessages((prev) => [...prev, assistantMsg].slice(-MAX_DISPLAY));
       onResponseRef.current?.();
     },
-    [loading]
+    [loading, createEvent, updateEvent, deleteEvent, deleteTodo]
   );
 
   const clear = useCallback(() => {

--- a/src/lib/applyWithUndo.ts
+++ b/src/lib/applyWithUndo.ts
@@ -1,0 +1,19 @@
+import { toast } from "sonner";
+
+export interface MutationRecord {
+  type: "create_event" | "update_event" | "delete_event" | "create_todo";
+  id: string;
+  snapshot: Record<string, unknown> | null;
+}
+
+const UNDO_TIMEOUT_MS = 30_000;
+
+export function applyWithUndo(label: string, undoFn: () => Promise<void>): void {
+  toast(label, {
+    duration: UNDO_TIMEOUT_MS,
+    action: {
+      label: "Undo",
+      onClick: () => void undoFn(),
+    },
+  });
+}


### PR DESCRIPTION
Completes the undo toast feature — the Edge Function changes (toolHandlers + index) are already in main but the client-side pieces were missing.

- Adds `src/lib/applyWithUndo.ts` (Sonner undo toast helper + MutationRecord type)
- Rewrites `src/hooks/useAIAssistant.ts` to import useEvents/useTodos, process the mutations array from each AI response, and fire one undo toast per mutation
- Fixes the TypeScript cast error (`Record<string, unknown> | null` → `unknown` → `CreateEventInput`)