### PR TITLE
feat: pipe voice transcript through edge function and speak response via SpeechSynthesis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.enablePaths": ["supabase/functions"],
+  "deno.lint": true
+}

--- a/src/components/ai/AIAssistant.tsx
+++ b/src/components/ai/AIAssistant.tsx
@@ -37,7 +37,7 @@ interface PanelContentProps {
   messages: ChatMessage[];
   loading: boolean;
   error: string | null;
-  onSend: (text: string) => Promise<void>;
+  onSend: (text: string, opts?: { voice?: boolean }) => Promise<void>;
   onClear: () => void;
   onClose: () => void;
 }
@@ -69,7 +69,7 @@ function PanelContent({ messages, loading, error, onSend, onClear, onClose }: Pa
   }
 
   function handleVoiceFinal(text: string) {
-    void onSend(text);
+    void onSend(text, { voice: true });
   }
 
   return (

--- a/src/hooks/useAIAssistant.ts
+++ b/src/hooks/useAIAssistant.ts
@@ -33,7 +33,7 @@ export function useAIAssistant(onResponse?: () => void) {
   const { deleteTodo } = useTodos();
 
   const send = useCallback(
-    async (text: string) => {
+    async (text: string, opts?: { voice?: boolean }) => {
       const trimmed = text.trim();
       if (!trimmed || loading) return;
 
@@ -53,6 +53,7 @@ export function useAIAssistant(onResponse?: () => void) {
             conversation_id: conversationIdRef.current ?? undefined,
             message: trimmed,
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            voice: opts?.voice ?? false,
           },
         }
       );
@@ -87,6 +88,11 @@ export function useAIAssistant(onResponse?: () => void) {
       };
       setMessages((prev) => [...prev, assistantMsg].slice(-MAX_DISPLAY));
       onResponseRef.current?.();
+
+      if (opts?.voice) {
+        window.speechSynthesis.cancel();
+        window.speechSynthesis.speak(new SpeechSynthesisUtterance(data.message));
+      }
     },
     [loading, createEvent, updateEvent, deleteEvent, deleteTodo]
   );

--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -31,6 +31,7 @@ interface AssistantRequest {
   conversation_id?: string;
   message: string;
   timezone?: string;
+  voice?: boolean;
 }
 
 const CORS_HEADERS = {
@@ -140,13 +141,13 @@ serve(async (req: Request) => {
 
     if (response.stop_reason === "tool_use") {
       const toolUseBlocks = response.content.filter(
-        (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+        (b: Anthropic.ContentBlock): b is Anthropic.ToolUseBlock => b.type === "tool_use"
       );
 
       messages = [...messages, { role: "assistant", content: response.content }];
 
       const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
-        toolUseBlocks.map(async (block) => {
+        toolUseBlocks.map(async (block: Anthropic.ToolUseBlock) => {
           const result = await executeTool(block, supabase, userData.user.id);
           if (result.mutation) mutations.push(result.mutation as MutationRecord);
           return {
@@ -163,8 +164,8 @@ serve(async (req: Request) => {
 
     // end_turn or max_tokens — extract final text and stop
     assistantText = response.content
-      .filter((b): b is Anthropic.TextBlock => b.type === "text")
-      .map((b) => b.text)
+      .filter((b: Anthropic.ContentBlock): b is Anthropic.TextBlock => b.type === "text")
+      .map((b: Anthropic.TextBlock) => b.text)
       .join("\n");
     break;
   }
@@ -172,8 +173,8 @@ serve(async (req: Request) => {
   // ── 4. Persist updated conversation (trimmed to last 50 messages) ─────────────
   const updatedMessages: StoredMessage[] = [
     ...history,
-    { role: "user", content: body.message },
-    { role: "assistant", content: assistantText },
+    { role: "user" as const, content: body.message },
+    { role: "assistant" as const, content: assistantText },
   ].slice(-MAX_STORED_MESSAGES);
 
   if (conversationId) {

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "lib": ["deno.window"],
+    "strict": true
+  }
+}


### PR DESCRIPTION
- Added voice?: boolean to the send() call in useAIAssistant — when true, the flag is included in the Edge Function request payload and after the response arrives, window.speechSynthesis.speak() reads the assistant's reply aloud (cancelling any prior speech first)

- Updated AIAssistant.tsx to pass { voice: true } only when sending via the mic button (handleVoiceFinal), so TTS fires on voice-initiated messages but not on regular keyboard sends

- Added voice?: boolean to the AssistantRequest interface in the Edge Function so the payload is accepted cleanly

- Fixed pre-existing type errors in index.ts: added as const to role literals to satisfy the StoredMessage[] type, and added explicit Anthropic.ContentBlock / Anthropic.TextBlock annotations to filter/map callbacks

- Added supabase/functions/deno.json and .vscode/settings.json to enable the Deno VS Code extension for the functions directory, resolving IDE errors from Deno-specific module specifiers and the Deno global