### PR TITLE
fix: keyword priority inference (J2) — closes #73

### DIFF
--- a/src/lib/priorityInference.ts
+++ b/src/lib/priorityInference.ts
@@ -1,0 +1,12 @@
+import type { Priority } from "../types";
+
+const URGENT = /\b(asap|urgent|critical|emergency|right ?now)\b/i;
+const HIGH = /\b(important|priority|must|hi(gh)? ?prio)\b/i;
+const LOW = /\b(someday|eventually|whenever|low ?prio|maybe|sometime)\b/i;
+
+export function inferPriorityFromText(text: string): Priority | null {
+  if (URGENT.test(text)) return "urgent";
+  if (HIGH.test(text)) return "high";
+  if (LOW.test(text)) return "low";
+  return null;
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Calendar, Camera, Check, ImagePlus, LogOut, Pencil, Settings, Sparkles, Trash2, X } from "lucide-react";
 import AIAssistant from "../components/ai/AIAssistant";
 import { looksLikeNL } from "../lib/nlDetect";
+import { inferPriorityFromText } from "../lib/priorityInference";
 import { supabase } from "../lib/supabase";
 import { uploadTodoImage } from "../lib/imageUpload";
 import { useAuth } from "../hooks/useAuth";
@@ -1060,9 +1061,18 @@ function TodoPanel({ mobile = false, onRouteToAI }: { mobile?: boolean; onRouteT
       imageUrl = await uploadTodoImage(newImageFile, user.id);
     }
 
+    // Keyword-based priority inference for fast paths that skip the AI.
+    // Only kicks in when the user left the priority at its default (medium);
+    // if they explicitly picked a level, we respect it.
+    let appliedPriority = newPriority;
+    if (newPriority === "medium") {
+      const inferred = inferPriorityFromText(trimmedTitle);
+      if (inferred) appliedPriority = inferred;
+    }
+
     const todoId = await createTodo({
       title: trimmedTitle,
-      priority: newPriority,
+      priority: appliedPriority,
       category_id: newCategoryId,
       due_at: newDueAt || null,
       linked_event_id: linkedEventId,

--- a/tests/priorityInference.test.ts
+++ b/tests/priorityInference.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { inferPriorityFromText } from "../src/lib/priorityInference";
+
+describe("inferPriorityFromText", () => {
+  it("returns urgent for ASAP keywords", () => {
+    expect(inferPriorityFromText("Finish report ASAP")).toBe("urgent");
+    expect(inferPriorityFromText("urgent: send email")).toBe("urgent");
+    expect(inferPriorityFromText("critical bug fix")).toBe("urgent");
+    expect(inferPriorityFromText("Emergency call mom")).toBe("urgent");
+    expect(inferPriorityFromText("Pay rent right now")).toBe("urgent");
+  });
+
+  it("returns high for important/priority keywords", () => {
+    expect(inferPriorityFromText("Important: book flight")).toBe("high");
+    expect(inferPriorityFromText("Top priority — review PR")).toBe("high");
+    expect(inferPriorityFromText("Must remember birthday")).toBe("high");
+  });
+
+  it("returns low for backlog keywords", () => {
+    expect(inferPriorityFromText("Read book someday")).toBe("low");
+    expect(inferPriorityFromText("Maybe learn rust")).toBe("low");
+    expect(inferPriorityFromText("Eventually deep-clean garage")).toBe("low");
+    expect(inferPriorityFromText("Re-org photos whenever")).toBe("low");
+  });
+
+  it("returns null for plain text with no keywords", () => {
+    expect(inferPriorityFromText("Buy milk")).toBeNull();
+    expect(inferPriorityFromText("Call dentist")).toBeNull();
+    expect(inferPriorityFromText("Workout")).toBeNull();
+  });
+
+  it("urgent takes precedence over high", () => {
+    expect(inferPriorityFromText("urgent and important")).toBe("urgent");
+  });
+
+  it("high takes precedence over low", () => {
+    expect(inferPriorityFromText("important someday")).toBe("high");
+  });
+
+  it("is case-insensitive", () => {
+    expect(inferPriorityFromText("ASAP")).toBe("urgent");
+    expect(inferPriorityFromText("Asap")).toBe("urgent");
+    expect(inferPriorityFromText("asap")).toBe("urgent");
+  });
+
+  it("matches whole words only", () => {
+    expect(inferPriorityFromText("urgentcare appointment")).toBeNull();
+    expect(inferPriorityFromText("eventually")).toBe("low");
+    expect(inferPriorityFromText("eventualization study")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the J2 regression: a todo titled "Finish report ASAP" was being saved as Medium because plain (non-temporal) todos skip the AI \`infer-todo\` Edge Function path. Now a deterministic client-side regex catches priority keywords and applies them on insert, only when the user hasn't already picked a level.

Closes #73.

## Implementation

- \`src/lib/priorityInference.ts\` — three case-insensitive, whole-word regexes:
  - URGENT: \`asap\`, \`urgent\`, \`critical\`, \`emergency\`, \`right now\`
  - HIGH: \`important\`, \`priority\`, \`must\`, \`hi prio\`
  - LOW: \`someday\`, \`eventually\`, \`whenever\`, \`maybe\`, \`sometime\`, \`low prio\`
- \`inferPriorityFromText(text) → Priority | null\` returns the strongest match (urgent > high > low). null when nothing fires.
- \`DashboardPage.handleCreateTodo\` applies the heuristic only when the user left the priority dropdown at \"medium\". An explicit pick always wins.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run test:run\` — **84/84 pass**, 8 new tests cover urgent/high/low/null/case/precedence/whole-word
- [x] Pre-existing flow unchanged: temporal todos still route to AI panel (looksLikeNL) where AI handles priority
- [ ] Manual browser regression after merge: "Finish report ASAP" → urgent badge

## Why a regex and not AI

The AI route already covers temporal todos. Plain todos skipping AI was the gap. A 3-line regex is deterministic, instant, zero API cost; over-engineering with an AI call for "ASAP" would add latency and spend tokens for marginal gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)