### PR TITLE
fix(realtime): add todos to supabase_realtime publication

### DIFF
--- a/supabase/migrations/003_todos_realtime.sql
+++ b/supabase/migrations/003_todos_realtime.sql
@@ -1,0 +1,24 @@
+-- 003_todos_realtime.sql
+--
+-- Re-asserts the `public.todos` table on the `supabase_realtime` publication
+-- so the right-panel todo list live-updates after AI-driven inserts (and any
+-- other server-side mutation) without requiring a page reload.
+--
+-- Why: the publication was found empty in the live project despite migration
+-- 001 having declared `ALTER PUBLICATION supabase_realtime ADD TABLE events,
+-- todos;`. This patch is idempotent — it checks `pg_publication_tables`
+-- before adding so re-running on environments where it is already present is
+-- a no-op. Fixes #76.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'todos'
+  ) THEN
+    EXECUTE 'ALTER PUBLICATION supabase_realtime ADD TABLE public.todos';
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- Adds an idempotent migration (`003_todos_realtime.sql`) that re-asserts `public.todos` on the `supabase_realtime` publication so the right-panel todo list live-updates after AI-driven inserts without a page reload.
- Root cause: the live project's `supabase_realtime` publication was empty (`pg_publication_tables` returned 0 rows for the publication) despite migration 001 declaring `ALTER PUBLICATION supabase_realtime ADD TABLE events, todos;`. Events appeared to live-update only because `AIAssistant` calls `refreshEvents()` after every response via the `onResponse` hook in `useAIAssistant`; there is no equivalent for todos, so realtime is the only path and it was broken.
- Migration is idempotent (`DO $$ ... IF NOT EXISTS ... $$`), safe to re-run on environments where todos is already published.

No frontend changes — the existing channel/filter in `TodoContext.tsx` is correct.

Closes #76

## Test plan
- [x] Applied migration via Supabase MCP `apply_migration`; verified `pg_publication_tables` now contains `public.todos`.
- [x] With the dashboard open at `/dashboard`, inserted a row into `todos` directly via SQL using the test user's `user_id`. The panel updated from `0 ACTIVE` to `1 ACTIVE` and rendered the new todo title without a reload. Subsequent DELETE also propagated and brought the panel back to `0 ACTIVE`.
- [x] `npm run build` — passes.
- [x] `npm run test:run` — 75 tests pass; only `tests/todoReducer.test.ts` fails because the test setup is missing `VITE_SUPABASE_*` env vars (pre-existing on `main`, unrelated to this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)