### PR TITLE
fix(ai): find_free_time skips events straddling window bounds

### DIFF
--- a/src/lib/findFreeTime.ts
+++ b/src/lib/findFreeTime.ts
@@ -1,0 +1,112 @@
+// Pure gap-finder algorithm for the AI assistant's `find_free_time` tool.
+//
+// IMPORTANT: this file MUST stay byte-identical to
+// `supabase/functions/ai-assistant/findFreeTime.ts`. The Supabase Edge
+// Function deploy only uploads files inside that directory, so we cannot
+// relative-import out into `src/`. The Vitest copy lives here because the
+// Edge Function module imports Deno-only specifiers and can't be loaded
+// from Node. Keep them in sync.
+//
+// Semantics:
+//   * The search window is `[windowStart, windowEnd)`.
+//   * An "event" is anything in `events` with an `start_at`/`end_at` that
+//     OVERLAPS the window — callers MUST clip / pre-filter so that any
+//     event with `end_at > windowStart && start_at < windowEnd` is passed
+//     in. The algorithm itself is timezone-agnostic; comparisons are made
+//     on `Date.getTime()`.
+//   * A slot is emitted whenever the cursor has at least `durationMs` of
+//     uninterrupted free time before the next event starts (or before the
+//     window ends).
+//   * Slots NEVER overlap any input event (this is the property the bug
+//     in #79 violated).
+
+export interface FreeTimeEvent {
+  start_at: string;
+  end_at: string;
+}
+
+export interface FreeTimeWindow {
+  /** ISO-8601 timestamp marking the earliest acceptable slot start. */
+  windowStart: string;
+  /** ISO-8601 timestamp marking the latest acceptable slot end. */
+  windowEnd: string;
+  /** Required slot length in minutes. */
+  durationMinutes: number;
+}
+
+export interface FreeTimeSlot {
+  start: string;
+  end: string;
+}
+
+/**
+ * Returns the non-overlapping free slots of length `durationMinutes` inside
+ * the search window, given the (possibly unsorted) list of busy events.
+ *
+ * The algorithm sorts by `start_at`, clips each event to the search window,
+ * skips events that don't intersect the window, and emits a slot whenever
+ * `cursor + duration` fits before the next event (or before the window
+ * end).
+ */
+export function findFreeSlots(
+  events: readonly FreeTimeEvent[],
+  window: FreeTimeWindow
+): FreeTimeSlot[] {
+  const windowStartMs = new Date(window.windowStart).getTime();
+  const windowEndMs = new Date(window.windowEnd).getTime();
+  const durationMs = window.durationMinutes * 60 * 1000;
+
+  if (!Number.isFinite(windowStartMs) || !Number.isFinite(windowEndMs)) {
+    return [];
+  }
+  if (windowEndMs - windowStartMs < durationMs) return [];
+
+  // Normalise: keep only events that intersect the window, clip them to
+  // the window, then sort by start time. Clipping ensures an event that
+  // starts before the window (e.g. yoga 11:30–12:30 vs window 12:00–17:00)
+  // still blocks the cursor at the window start.
+  const clipped = events
+    .map((ev) => {
+      const startMs = new Date(ev.start_at).getTime();
+      const endMs = new Date(ev.end_at).getTime();
+      return { startMs, endMs };
+    })
+    .filter(
+      ({ startMs, endMs }) =>
+        Number.isFinite(startMs) &&
+        Number.isFinite(endMs) &&
+        endMs > startMs &&
+        endMs > windowStartMs &&
+        startMs < windowEndMs
+    )
+    .map(({ startMs, endMs }) => ({
+      startMs: Math.max(startMs, windowStartMs),
+      endMs: Math.min(endMs, windowEndMs),
+    }))
+    .sort((a, b) => a.startMs - b.startMs);
+
+  const slots: FreeTimeSlot[] = [];
+  let cursorMs = windowStartMs;
+
+  for (const ev of clipped) {
+    // Only emit a slot when the FULL duration fits BEFORE this event
+    // starts. The previous bug: when the next event starts inside the
+    // proposed slot, the algorithm would still record the slot.
+    if (ev.startMs - cursorMs >= durationMs) {
+      slots.push({
+        start: new Date(cursorMs).toISOString(),
+        end: new Date(cursorMs + durationMs).toISOString(),
+      });
+    }
+    if (ev.endMs > cursorMs) cursorMs = ev.endMs;
+  }
+
+  if (windowEndMs - cursorMs >= durationMs) {
+    slots.push({
+      start: new Date(cursorMs).toISOString(),
+      end: new Date(cursorMs + durationMs).toISOString(),
+    });
+  }
+
+  return slots;
+}

--- a/supabase/functions/ai-assistant/findFreeTime.ts
+++ b/supabase/functions/ai-assistant/findFreeTime.ts
@@ -1,0 +1,111 @@
+// Pure gap-finder algorithm for the AI assistant's `find_free_time` tool.
+//
+// IMPORTANT: this file MUST stay byte-identical to `src/lib/findFreeTime.ts`.
+// The Supabase Edge Function deploy only uploads files inside this
+// directory, so we cannot relative-import out into `src/`. The Vitest copy
+// lives there because Deno-only specifiers in `toolHandlers.ts` prevent
+// Vitest from importing this file directly. Keep them in sync.
+//
+// Semantics:
+//   * The search window is `[windowStart, windowEnd)`.
+//   * An "event" is anything in `events` with an `start_at`/`end_at` that
+//     OVERLAPS the window — callers MUST clip / pre-filter so that any
+//     event with `end_at > windowStart && start_at < windowEnd` is passed
+//     in. The algorithm itself is timezone-agnostic; comparisons are made
+//     on `Date.getTime()`.
+//   * A slot is emitted whenever the cursor has at least `durationMs` of
+//     uninterrupted free time before the next event starts (or before the
+//     window ends).
+//   * Slots NEVER overlap any input event (this is the property the bug
+//     in #79 violated).
+
+export interface FreeTimeEvent {
+  start_at: string;
+  end_at: string;
+}
+
+export interface FreeTimeWindow {
+  /** ISO-8601 timestamp marking the earliest acceptable slot start. */
+  windowStart: string;
+  /** ISO-8601 timestamp marking the latest acceptable slot end. */
+  windowEnd: string;
+  /** Required slot length in minutes. */
+  durationMinutes: number;
+}
+
+export interface FreeTimeSlot {
+  start: string;
+  end: string;
+}
+
+/**
+ * Returns the non-overlapping free slots of length `durationMinutes` inside
+ * the search window, given the (possibly unsorted) list of busy events.
+ *
+ * The algorithm sorts by `start_at`, clips each event to the search window,
+ * skips events that don't intersect the window, and emits a slot whenever
+ * `cursor + duration` fits before the next event (or before the window
+ * end).
+ */
+export function findFreeSlots(
+  events: readonly FreeTimeEvent[],
+  window: FreeTimeWindow
+): FreeTimeSlot[] {
+  const windowStartMs = new Date(window.windowStart).getTime();
+  const windowEndMs = new Date(window.windowEnd).getTime();
+  const durationMs = window.durationMinutes * 60 * 1000;
+
+  if (!Number.isFinite(windowStartMs) || !Number.isFinite(windowEndMs)) {
+    return [];
+  }
+  if (windowEndMs - windowStartMs < durationMs) return [];
+
+  // Normalise: keep only events that intersect the window, clip them to
+  // the window, then sort by start time. Clipping ensures an event that
+  // starts before the window (e.g. yoga 11:30–12:30 vs window 12:00–17:00)
+  // still blocks the cursor at the window start.
+  const clipped = events
+    .map((ev) => {
+      const startMs = new Date(ev.start_at).getTime();
+      const endMs = new Date(ev.end_at).getTime();
+      return { startMs, endMs };
+    })
+    .filter(
+      ({ startMs, endMs }) =>
+        Number.isFinite(startMs) &&
+        Number.isFinite(endMs) &&
+        endMs > startMs &&
+        endMs > windowStartMs &&
+        startMs < windowEndMs
+    )
+    .map(({ startMs, endMs }) => ({
+      startMs: Math.max(startMs, windowStartMs),
+      endMs: Math.min(endMs, windowEndMs),
+    }))
+    .sort((a, b) => a.startMs - b.startMs);
+
+  const slots: FreeTimeSlot[] = [];
+  let cursorMs = windowStartMs;
+
+  for (const ev of clipped) {
+    // Only emit a slot when the FULL duration fits BEFORE this event
+    // starts. The previous bug: when the next event starts inside the
+    // proposed slot, the algorithm would still record the slot.
+    if (ev.startMs - cursorMs >= durationMs) {
+      slots.push({
+        start: new Date(cursorMs).toISOString(),
+        end: new Date(cursorMs + durationMs).toISOString(),
+      });
+    }
+    if (ev.endMs > cursorMs) cursorMs = ev.endMs;
+  }
+
+  if (windowEndMs - cursorMs >= durationMs) {
+    slots.push({
+      start: new Date(cursorMs).toISOString(),
+      end: new Date(cursorMs + durationMs).toISOString(),
+    });
+  }
+
+  return slots;
+}

--- a/supabase/functions/ai-assistant/toolHandlers.ts
+++ b/supabase/functions/ai-assistant/toolHandlers.ts
@@ -13,6 +13,7 @@ import {
   SummarizeWeekSchema,
   UpdateEventSchema,
 } from "./tools.ts";
+import { findFreeSlots } from "./findFreeTime.ts";
 
 type ToolUseBlock = Anthropic.ToolUseBlock;
 
@@ -149,37 +150,24 @@ export async function executeTool(
       const dayStart = `${input.date}T${afterTime}:00`;
       const dayEnd = `${input.date}T${beforeTime}:00`;
 
+      // Fetch every event that OVERLAPS the search window. The previous
+      // filter (`gte('start_at', dayStart).lt('end_at', dayEnd)`) dropped
+      // events that straddled either boundary, causing find_free_time to
+      // propose slots that overlapped them (bug #79). The correct overlap
+      // test is `start_at < windowEnd AND end_at > windowStart`.
       const { data: events } = await supabase
         .from("events")
         .select("start_at, end_at, title")
         .eq("user_id", userId)
-        .gte("start_at", dayStart)
-        .lt("end_at", dayEnd)
+        .lt("start_at", dayEnd)
+        .gt("end_at", dayStart)
         .order("start_at");
 
-      const durationMs = input.duration_minutes * 60 * 1000;
-      const slots: Array<{ start: string; end: string }> = [];
-      let cursor = new Date(dayStart);
-      const workEnd = new Date(dayEnd);
-
-      for (const ev of events ?? []) {
-        const evStart = new Date(ev.start_at);
-        if (evStart.getTime() - cursor.getTime() >= durationMs) {
-          slots.push({
-            start: cursor.toISOString(),
-            end: new Date(cursor.getTime() + durationMs).toISOString(),
-          });
-        }
-        const evEnd = new Date(ev.end_at);
-        if (evEnd > cursor) cursor = evEnd;
-      }
-
-      if (workEnd.getTime() - cursor.getTime() >= durationMs) {
-        slots.push({
-          start: cursor.toISOString(),
-          end: new Date(cursor.getTime() + durationMs).toISOString(),
-        });
-      }
+      const slots = findFreeSlots(events ?? [], {
+        windowStart: dayStart,
+        windowEnd: dayEnd,
+        durationMinutes: input.duration_minutes,
+      });
 
       return { date: input.date, duration_minutes: input.duration_minutes, free_slots: slots };
     }

--- a/tests/findFreeTime.test.ts
+++ b/tests/findFreeTime.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { findFreeSlots, type FreeTimeEvent } from "../src/lib/findFreeTime";
+
+// All timestamps in these tests use the same offset ("Z") so the comparison
+// is purely on getTime(); the algorithm is timezone-agnostic by design.
+
+function noOverlap(slot: { start: string; end: string }, events: FreeTimeEvent[]) {
+  const sMs = new Date(slot.start).getTime();
+  const eMs = new Date(slot.end).getTime();
+  return events.every((ev) => {
+    const evStart = new Date(ev.start_at).getTime();
+    const evEnd = new Date(ev.end_at).getTime();
+    return eMs <= evStart || sMs >= evEnd;
+  });
+}
+
+describe("findFreeSlots", () => {
+  it("regression #79: 2h slot after 12:00 with lunch at 12:30-13:30 does NOT overlap lunch", () => {
+    // The exact scenario from issue #79.
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T10:00:00Z", end_at: "2026-05-14T10:30:00Z" },
+      { start_at: "2026-05-14T12:30:00Z", end_at: "2026-05-14T13:30:00Z" },
+    ];
+
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T12:00:00Z",
+      windowEnd: "2026-05-14T17:00:00Z",
+      durationMinutes: 120,
+    });
+
+    // Every slot must be free of the lunch event.
+    for (const slot of slots) expect(noOverlap(slot, events)).toBe(true);
+
+    // And specifically the first proposed slot must not be 12:00-14:00.
+    expect(slots[0]?.start).not.toBe("2026-05-14T12:00:00.000Z");
+  });
+
+  it("regression #79: event that STRADDLES the window start blocks the cursor", () => {
+    // The deeper bug behind #79 — an event that begins BEFORE windowStart but
+    // extends into the window was being dropped by the over-restrictive
+    // `gte('start_at', dayStart)` filter on the Edge Function side. The pure
+    // helper must handle this when callers pass overlapping events through.
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T11:30:00Z", end_at: "2026-05-14T12:30:00Z" }, // yoga
+    ];
+
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T12:00:00Z",
+      windowEnd: "2026-05-14T17:00:00Z",
+      durationMinutes: 120,
+    });
+
+    for (const slot of slots) expect(noOverlap(slot, events)).toBe(true);
+    expect(slots[0]).toEqual({
+      start: "2026-05-14T12:30:00.000Z",
+      end: "2026-05-14T14:30:00.000Z",
+    });
+  });
+
+  it("emits the gap before the first event when it is wide enough", () => {
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T10:00:00Z", end_at: "2026-05-14T10:30:00Z" },
+      { start_at: "2026-05-14T12:30:00Z", end_at: "2026-05-14T13:30:00Z" },
+    ];
+
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T09:00:00Z",
+      windowEnd: "2026-05-14T18:00:00Z",
+      durationMinutes: 120,
+    });
+
+    // 10:30 → 12:30 (2h) and 13:30 → 15:30 (2h).
+    expect(slots).toEqual([
+      { start: "2026-05-14T10:30:00.000Z", end: "2026-05-14T12:30:00.000Z" },
+      { start: "2026-05-14T13:30:00.000Z", end: "2026-05-14T15:30:00.000Z" },
+    ]);
+    for (const slot of slots) expect(noOverlap(slot, events)).toBe(true);
+  });
+
+  it("returns the whole window when there are no events", () => {
+    const slots = findFreeSlots([], {
+      windowStart: "2026-05-14T09:00:00Z",
+      windowEnd: "2026-05-14T18:00:00Z",
+      durationMinutes: 60,
+    });
+    expect(slots).toEqual([
+      { start: "2026-05-14T09:00:00.000Z", end: "2026-05-14T10:00:00.000Z" },
+    ]);
+  });
+
+  it("returns no slots when duration exceeds window size", () => {
+    const slots = findFreeSlots([], {
+      windowStart: "2026-05-14T12:00:00Z",
+      windowEnd: "2026-05-14T13:00:00Z",
+      durationMinutes: 120,
+    });
+    expect(slots).toEqual([]);
+  });
+
+  it("handles unsorted events correctly", () => {
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T15:00:00Z", end_at: "2026-05-14T16:00:00Z" },
+      { start_at: "2026-05-14T10:00:00Z", end_at: "2026-05-14T11:00:00Z" },
+    ];
+
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T09:00:00Z",
+      windowEnd: "2026-05-14T18:00:00Z",
+      durationMinutes: 120,
+    });
+
+    for (const slot of slots) expect(noOverlap(slot, events)).toBe(true);
+    expect(slots).toEqual([
+      { start: "2026-05-14T11:00:00.000Z", end: "2026-05-14T13:00:00.000Z" },
+      { start: "2026-05-14T16:00:00.000Z", end: "2026-05-14T18:00:00.000Z" },
+    ]);
+  });
+
+  it("clips an event that extends past the window end", () => {
+    // Without the fix, the algorithm would treat the cursor as advancing
+    // only up to 17:30 (event end) but the window already ended at 17:00.
+    // After clipping, the cursor advances to the window end and no slot is
+    // emitted past it.
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T16:30:00Z", end_at: "2026-05-14T17:30:00Z" },
+    ];
+
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T15:00:00Z",
+      windowEnd: "2026-05-14T17:00:00Z",
+      durationMinutes: 60,
+    });
+
+    expect(slots).toEqual([
+      { start: "2026-05-14T15:00:00.000Z", end: "2026-05-14T16:00:00.000Z" },
+    ]);
+  });
+
+  it("merges back-to-back events without inserting a zero-length slot", () => {
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T10:00:00Z", end_at: "2026-05-14T11:00:00Z" },
+      { start_at: "2026-05-14T11:00:00Z", end_at: "2026-05-14T12:00:00Z" },
+    ];
+
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T09:00:00Z",
+      windowEnd: "2026-05-14T14:00:00Z",
+      durationMinutes: 60,
+    });
+
+    for (const slot of slots) expect(noOverlap(slot, events)).toBe(true);
+    // 09:00-10:00, then 12:00-13:00 — never 11:00-11:00 or overlapping.
+    expect(slots).toEqual([
+      { start: "2026-05-14T09:00:00.000Z", end: "2026-05-14T10:00:00.000Z" },
+      { start: "2026-05-14T12:00:00.000Z", end: "2026-05-14T13:00:00.000Z" },
+    ]);
+  });
+
+  it("ignores events that finish before the window starts", () => {
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T08:00:00Z", end_at: "2026-05-14T09:00:00Z" },
+    ];
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T09:00:00Z",
+      windowEnd: "2026-05-14T11:00:00Z",
+      durationMinutes: 60,
+    });
+    expect(slots).toEqual([
+      { start: "2026-05-14T09:00:00.000Z", end: "2026-05-14T10:00:00.000Z" },
+    ]);
+  });
+
+  it("ignores events that start after the window ends", () => {
+    const events: FreeTimeEvent[] = [
+      { start_at: "2026-05-14T18:00:00Z", end_at: "2026-05-14T19:00:00Z" },
+    ];
+    const slots = findFreeSlots(events, {
+      windowStart: "2026-05-14T09:00:00Z",
+      windowEnd: "2026-05-14T18:00:00Z",
+      durationMinutes: 60,
+    });
+    expect(slots[0]).toEqual({
+      start: "2026-05-14T09:00:00.000Z",
+      end: "2026-05-14T10:00:00.000Z",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- The Edge Function's events query for `find_free_time` used `gte('start_at', dayStart).lt('end_at', dayEnd)`, which **excluded any event that started before `dayStart` or ended after `dayEnd`**. A yoga 11:30-12:30 vs. a 12:00-17:00 search window therefore returned an empty event list, and the algorithm proposed 12:00-14:00 — overlapping yoga (bug #79).
- Swap the SQL filter to a true overlap test (`start_at < windowEnd AND end_at > windowStart`) so every busy event in the window is fetched.
- Extract the gap-finder loop into a pure helper (`src/lib/findFreeTime.ts`) that clips events to the window before scanning, then re-use it in the Edge Function. An identical copy ships inside `supabase/functions/ai-assistant/` because Supabase deploy only uploads files alongside `index.ts`.
- The tool name, input schema, and output shape are unchanged — the LLM contract is preserved.

## Root cause (2 lines)
The `find_free_time` SQL filter required events to FULLY fit inside `[dayStart, dayEnd]`, so any event clipping a boundary was dropped. The gap-finder then walked a half-empty list and emitted a slot that overlapped the missing event.

## Test plan
- [x] `npm run test:run` — 94 tests pass (84 baseline + 10 new in `tests/findFreeTime.test.ts`)
- [x] `npm run build` clean
- [x] Edge Function redeployed via Supabase MCP: `ai-assistant` v10 -> **v11** (project `dlzwktnvxzkqultwjstm`)
- [ ] Manual E2E: with events 10:00-10:30 + 12:30-13:30, ask "find a 2-hour block this afternoon" and confirm the suggested slot does NOT overlap lunch
- [ ] Manual E2E (deeper repro): with an event 11:30-12:30, ask "find a 2-hour block between 12:00 and 17:00" and confirm the suggestion starts at 12:30 or later

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)