### PR TITLE
chore(test): exclude .claude/ agent worktrees from vitest

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./tests/setup.ts"],
-    css: true
+    css: true,
+    exclude: ["**/node_modules/**", "**/dist/**", "**/.claude/**"]
   }
 });


### PR DESCRIPTION
One-line vitest exclude addition so the harness's locked agent worktrees don't pollute the test suite. Verified: 7 files / 94 tests green.