### PR TITLE
feat(notifications): browser reminders for upcoming events

### DIFF
--- a/src/components/calendar/EventForm.tsx
+++ b/src/components/calendar/EventForm.tsx
@@ -316,6 +316,7 @@ function EventForm({
             { label: "15m before", value: 15 },
             { label: "30m before", value: 30 },
             { label: "1h before", value: 60 },
+            { label: "1d before", value: 1440 },
           ].map((opt) => {
             const isSelected = watch("reminder_offset_minutes") === opt.value;
             return (

--- a/src/components/common/NotificationsToggle.tsx
+++ b/src/components/common/NotificationsToggle.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useState } from "react";
+import { Bell, BellOff, BellRing } from "lucide-react";
+import { toast } from "sonner";
+
+export type NotificationPermissionState =
+  | NotificationPermission
+  | "unsupported";
+
+interface NotificationsToggleProps {
+  /**
+   * Optional callback so the parent (typically `DashboardPage`) can wire the
+   * resulting permission into a scheduler hook like `useEventReminders`.
+   * Fires on mount with the initial value and on every change thereafter.
+   */
+  onPermissionChange?: (permission: NotificationPermissionState) => void;
+}
+
+function readInitialPermission(): NotificationPermissionState {
+  if (typeof window === "undefined") return "unsupported";
+  if (typeof Notification === "undefined") return "unsupported";
+  return Notification.permission;
+}
+
+/**
+ * Small header-bar button that requests Notification permission on click.
+ *
+ * - Stays available when permission is `default` or `denied` so the user
+ *   can re-trigger the prompt at any time.
+ * - When granted, collapses to a subtle "Notifications enabled" indicator.
+ * - When the browser doesn't support `Notification` at all, renders a
+ *   muted, disabled chip explaining why.
+ *
+ * Per spec: this component never asks for permission automatically — only
+ * the explicit click invokes `Notification.requestPermission()`.
+ */
+export default function NotificationsToggle({
+  onPermissionChange,
+}: NotificationsToggleProps) {
+  const [permission, setPermission] = useState<NotificationPermissionState>(
+    readInitialPermission
+  );
+  const [requesting, setRequesting] = useState(false);
+
+  // Notify the parent on mount and whenever permission flips.
+  useEffect(() => {
+    onPermissionChange?.(permission);
+  }, [permission, onPermissionChange]);
+
+  const handleRequest = useCallback(async () => {
+    if (permission === "unsupported") return;
+    if (typeof Notification === "undefined") return;
+    if (requesting) return;
+
+    setRequesting(true);
+    try {
+      const result = await Notification.requestPermission();
+      setPermission(result);
+      if (result === "granted") {
+        toast.success("Notifications enabled");
+      } else if (result === "denied") {
+        toast.error(
+          "Notifications blocked — re-enable them in your browser site settings."
+        );
+      } else {
+        // User dismissed the prompt — keep the button visible so they can
+        // try again later.
+        toast.message("Notifications dismissed");
+      }
+    } catch (err) {
+      console.warn("Notification permission request failed:", err);
+      toast.error("Could not request notification permission");
+    } finally {
+      setRequesting(false);
+    }
+  }, [permission, requesting]);
+
+  if (permission === "unsupported") {
+    return (
+      <span
+        aria-label="Notifications not supported in this browser"
+        className="inline-flex items-center gap-1.5 rounded-full px-2 py-2 text-xs text-slate-400 dark:text-slate-500"
+        title="Notifications not supported in this browser"
+      >
+        <BellOff className="h-5 w-5" />
+      </span>
+    );
+  }
+
+  if (permission === "granted") {
+    return (
+      <span
+        aria-label="Notifications enabled"
+        className="inline-flex items-center gap-1.5 rounded-full p-2 text-cyan-700 dark:text-cyan-300"
+        title="Notifications enabled"
+      >
+        <BellRing className="h-5 w-5" />
+      </span>
+    );
+  }
+
+  return (
+    <button
+      aria-label="Enable browser notifications"
+      className="inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-semibold text-slate-500 ring-1 ring-slate-900/10 transition hover:bg-slate-900/[0.06] hover:text-cyan-700 disabled:opacity-50 dark:text-slate-400 dark:ring-slate-700/50 dark:hover:bg-slate-800/60 dark:hover:text-cyan-300"
+      disabled={requesting}
+      onClick={() => {
+        void handleRequest();
+      }}
+      title="Enable browser notifications"
+      type="button"
+    >
+      <Bell className="h-4 w-4" />
+      <span className="hidden sm:inline">
+        {requesting ? "Requesting…" : "Enable notifications"}
+      </span>
+    </button>
+  );
+}

--- a/src/hooks/useEventReminders.ts
+++ b/src/hooks/useEventReminders.ts
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from "react";
+import { format, parseISO } from "date-fns";
+import type { Event } from "../types";
+
+/**
+ * Maximum lookahead window — only events whose reminder fires within this
+ * many milliseconds from "now" are scheduled. 24 hours keeps the timeout
+ * table small (setTimeout can hold thousands of timers, but no need).
+ */
+const LOOKAHEAD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Re-scan the events list every 6 hours so events that crossed into the
+ * 24-hour window get picked up without requiring a page refresh.
+ */
+const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Build a friendly "Today at 3:45 PM" / "Tomorrow at 9:00 AM" body line.
+ */
+function niceTimeString(date: Date): string {
+  const now = new Date();
+  const isSameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const isTomorrow =
+    date.getFullYear() === tomorrow.getFullYear() &&
+    date.getMonth() === tomorrow.getMonth() &&
+    date.getDate() === tomorrow.getDate();
+
+  if (isSameDay) return `Today at ${format(date, "h:mm a")}`;
+  if (isTomorrow) return `Tomorrow at ${format(date, "h:mm a")}`;
+  return format(date, "EEE MMM d, h:mm a");
+}
+
+function clearAllTimers(map: Map<string, number>) {
+  for (const handle of map.values()) {
+    window.clearTimeout(handle);
+  }
+  map.clear();
+}
+
+/**
+ * useEventReminders
+ *
+ * Schedules a browser `Notification` for each upcoming event with a
+ * `reminder_offset_minutes` value. Side-effect only — returns nothing.
+ *
+ * - Only schedules when `permission === "granted"`.
+ * - Skips events whose reminder time has already passed.
+ * - Caps lookahead at 24h so we don't queue thousands of `setTimeout`s.
+ * - Tracks which events have already fired in a `Set` ref so each event
+ *   notifies at most once per page session.
+ * - Re-runs whenever the `events` array or `permission` changes, and also
+ *   on a 6-hour interval to pick up further-out events.
+ *
+ * Cleanup: on unmount (and before each re-schedule), every queued
+ * `setTimeout` is cleared. The refresh `setInterval` is cleared on unmount.
+ */
+export function useEventReminders(
+  events: Event[],
+  permission: NotificationPermission | "unsupported"
+) {
+  // Map from event-id → timeout handle. Lets us cancel pending timers when
+  // the events list changes or the component unmounts.
+  const timersRef = useRef<Map<string, number>>(new Map());
+  // Tracks event ids that have already fired this session, so the same
+  // reminder never goes off twice (e.g. if the events array is rebuilt).
+  const sentRef = useRef<Set<string>>(new Set());
+  // Tick counter — incrementing it triggers a re-run of the scheduling
+  // effect, which is how the 6-hour refresh interval works.
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (permission !== "granted") {
+      // No permission → cancel anything previously queued and bail.
+      clearAllTimers(timersRef.current);
+      return;
+    }
+    if (typeof Notification === "undefined") return;
+
+    const now = Date.now();
+    const horizon = now + LOOKAHEAD_MS;
+
+    // Reset any previously scheduled timers — we re-compute from the current
+    // events list each pass to keep the timer map in sync with the source.
+    clearAllTimers(timersRef.current);
+
+    for (const ev of events) {
+      const offset = ev.reminder_offset_minutes;
+      if (offset === null || offset === undefined) continue;
+
+      // Skip events we've already notified about in this session.
+      if (sentRef.current.has(ev.id)) continue;
+
+      let startMs: number;
+      try {
+        startMs = parseISO(ev.start_at).getTime();
+      } catch {
+        continue;
+      }
+      if (Number.isNaN(startMs)) continue;
+
+      const fireAt = startMs - offset * 60 * 1000;
+      const delay = fireAt - now;
+
+      // Already past — don't fire stale notifications.
+      if (delay <= 0) continue;
+      // Beyond our lookahead window — the 6-hour interval will catch it.
+      if (fireAt > horizon) continue;
+
+      const evId = ev.id;
+      const title = ev.title;
+      const start = new Date(startMs);
+
+      const handle = window.setTimeout(() => {
+        // Permission could have been revoked while we waited.
+        if (typeof Notification === "undefined") return;
+        if (Notification.permission !== "granted") return;
+        // Guard double-fire (defensive — the Set should keep us honest).
+        if (sentRef.current.has(evId)) return;
+
+        try {
+          const notification = new Notification(title, {
+            body: niceTimeString(start),
+            tag: evId,
+          });
+          // Optional click-to-focus. Wrapped — some browsers don't honour
+          // this and we don't want to break the timer if it throws.
+          notification.onclick = () => {
+            try {
+              window.focus();
+              notification.close();
+            } catch {
+              /* ignore */
+            }
+          };
+        } catch (err) {
+          // Notification constructor can throw if the user disabled them
+          // mid-session; swallow it so the rest of the timers keep working.
+          console.warn("Failed to dispatch reminder notification:", err);
+        }
+        sentRef.current.add(evId);
+        timersRef.current.delete(evId);
+      }, delay);
+
+      timersRef.current.set(evId, handle);
+    }
+
+    return () => {
+      clearAllTimers(timersRef.current);
+    };
+  }, [events, permission, refreshTick]);
+
+  // Daily-ish refresh: re-run the scheduling pass every 6 hours so events
+  // that were beyond the 24h window earlier get queued once they're inside.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (permission !== "granted") return;
+    const id = window.setInterval(() => {
+      setRefreshTick((t) => t + 1);
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [permission]);
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -17,7 +17,11 @@ import CalendarView from "../components/calendar/CalendarView";
 import EventModal from "../components/calendar/EventModal";
 import HolidayModal from "../components/calendar/HolidayModal";
 import ThemeToggle from "../components/common/ThemeToggle";
+import NotificationsToggle, {
+  type NotificationPermissionState,
+} from "../components/common/NotificationsToggle";
 import BrowserSupportBanner from "../components/common/BrowserSupportBanner";
+import { useEventReminders } from "../hooks/useEventReminders";
 import type { EventInput } from "@fullcalendar/core";
 import { Draggable } from "@fullcalendar/interaction";
 import type { EventFormValues } from "../lib/schemas/event";
@@ -245,11 +249,13 @@ function DashboardHeader({
   onLogout,
   onOpenSettings,
   onOpenTodos,
+  onNotificationPermissionChange,
 }: {
   displayName: string;
   onLogout: () => void;
   onOpenSettings: () => void;
   onOpenTodos: () => void;
+  onNotificationPermissionChange: (permission: NotificationPermissionState) => void;
 }) {
   return (
     <header className="sticky top-0 z-20 border-b border-slate-900/10 bg-white/85 backdrop-blur-xl dark:border-white/10 dark:bg-slate-950/80">
@@ -293,6 +299,7 @@ function DashboardHeader({
           >
             <Settings className="h-5 w-5" />
           </button>
+          <NotificationsToggle onPermissionChange={onNotificationPermissionChange} />
           <ThemeToggle />
           <button
             className="rounded-full p-2 text-slate-500 transition hover:bg-slate-900/[0.06] hover:text-red-600 dark:text-slate-400 dark:hover:bg-slate-800/60 dark:hover:text-red-400"
@@ -1551,6 +1558,19 @@ export default function DashboardPage() {
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [aiQueuedMessage, setAiQueuedMessage] = useState<string | undefined>();
+  const [notificationPermission, setNotificationPermission] =
+    useState<NotificationPermissionState>(() => {
+      if (typeof window === "undefined") return "unsupported";
+      if (typeof Notification === "undefined") return "unsupported";
+      return Notification.permission;
+    });
+  const handleNotificationPermissionChange = useCallback(
+    (next: NotificationPermissionState) => {
+      setNotificationPermission(next);
+    },
+    []
+  );
+  useEventReminders(events, notificationPermission);
 
   function openAIWithMessage(msg: string) {
     setAiQueuedMessage(msg);
@@ -1737,6 +1757,7 @@ export default function DashboardPage() {
         onLogout={handleLogout}
         onOpenSettings={() => navigate("/settings")}
         onOpenTodos={() => setMobileDrawerOpen(true)}
+        onNotificationPermissionChange={handleNotificationPermissionChange}
       />
 
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 lg:py-8">

--- a/tests/useEventReminders.test.tsx
+++ b/tests/useEventReminders.test.tsx
@@ -1,0 +1,150 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEventReminders } from "../src/hooks/useEventReminders";
+import type { Event } from "../src/types";
+
+const REAL_NOTIFICATION = (globalThis as { Notification?: unknown }).Notification;
+
+function buildEvent(overrides: Partial<Event> = {}): Event {
+  const base: Event = {
+    id: "evt-1",
+    user_id: "user-1",
+    title: "Standup",
+    description: null,
+    start_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    end_at: new Date(Date.now() + 35 * 60 * 1000).toISOString(),
+    all_day: false,
+    category_id: null,
+    rrule: null,
+    reminder_offset_minutes: 0,
+    created_by_ai: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+  return { ...base, ...overrides };
+}
+
+let constructed: { title: string; body?: string; tag?: string }[] = [];
+
+class FakeNotification {
+  static permission: NotificationPermission = "granted";
+  static requestPermission = vi.fn(async () => "granted" as NotificationPermission);
+  public onclick: (() => void) | null = null;
+  constructor(public title: string, public options?: NotificationOptions) {
+    constructed.push({ title, body: options?.body, tag: options?.tag });
+  }
+  close() {
+    /* noop */
+  }
+}
+
+describe("useEventReminders", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    constructed = [];
+    (globalThis as unknown as { Notification: unknown }).Notification =
+      FakeNotification;
+    FakeNotification.permission = "granted";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (REAL_NOTIFICATION === undefined) {
+      delete (globalThis as unknown as { Notification?: unknown }).Notification;
+    } else {
+      (globalThis as unknown as { Notification: unknown }).Notification =
+        REAL_NOTIFICATION;
+    }
+  });
+
+  it("does nothing when permission is not granted", () => {
+    const fireIn = 2 * 60 * 1000; // 2 minutes
+    const ev = buildEvent({
+      start_at: new Date(Date.now() + fireIn).toISOString(),
+      reminder_offset_minutes: 0,
+    });
+
+    renderHook(() => useEventReminders([ev], "default"));
+    vi.advanceTimersByTime(fireIn + 10);
+
+    expect(constructed.length).toBe(0);
+  });
+
+  it("schedules a notification at the offset boundary when granted", () => {
+    const fireIn = 2 * 60 * 1000;
+    const ev = buildEvent({
+      start_at: new Date(Date.now() + fireIn).toISOString(),
+      reminder_offset_minutes: 0,
+      title: "Quick chat",
+    });
+
+    renderHook(() => useEventReminders([ev], "granted"));
+    expect(constructed.length).toBe(0);
+
+    vi.advanceTimersByTime(fireIn + 10);
+
+    expect(constructed.length).toBe(1);
+    expect(constructed[0].title).toBe("Quick chat");
+    expect(constructed[0].tag).toBe(ev.id);
+  });
+
+  it("skips events whose reminder has already passed", () => {
+    const ev = buildEvent({
+      start_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      reminder_offset_minutes: 0,
+    });
+
+    renderHook(() => useEventReminders([ev], "granted"));
+    vi.advanceTimersByTime(60 * 1000);
+
+    expect(constructed.length).toBe(0);
+  });
+
+  it("skips events without a reminder offset", () => {
+    const ev = buildEvent({
+      start_at: new Date(Date.now() + 60 * 1000).toISOString(),
+      reminder_offset_minutes: null,
+    });
+
+    renderHook(() => useEventReminders([ev], "granted"));
+    vi.advanceTimersByTime(2 * 60 * 1000);
+
+    expect(constructed.length).toBe(0);
+  });
+
+  it("does not fire the same event twice across re-renders", () => {
+    const fireIn = 2 * 60 * 1000;
+    const ev = buildEvent({
+      start_at: new Date(Date.now() + fireIn).toISOString(),
+      reminder_offset_minutes: 0,
+    });
+
+    const { rerender } = renderHook(
+      ({ events }: { events: Event[] }) => useEventReminders(events, "granted"),
+      { initialProps: { events: [ev] } }
+    );
+
+    vi.advanceTimersByTime(fireIn + 10);
+    expect(constructed.length).toBe(1);
+
+    // Re-render with a new array containing the same event — should NOT
+    // re-fire the same notification.
+    rerender({ events: [{ ...ev }] });
+    vi.advanceTimersByTime(fireIn + 10);
+    expect(constructed.length).toBe(1);
+  });
+
+  it("skips events whose reminder is beyond the 24h lookahead window", () => {
+    const dayPlus = 25 * 60 * 60 * 1000;
+    const ev = buildEvent({
+      start_at: new Date(Date.now() + dayPlus).toISOString(),
+      reminder_offset_minutes: 0,
+    });
+
+    renderHook(() => useEventReminders([ev], "granted"));
+    vi.advanceTimersByTime(2 * 60 * 60 * 1000); // 2 hours
+
+    expect(constructed.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a header **Enable notifications** button (next to the theme toggle) that requests `Notification.permission` only on explicit click. Once granted, the button collapses to a subtle `BellRing` indicator; if dismissed or denied the button stays visible so the user can re-request.
- New `useEventReminders` hook schedules a `setTimeout` per upcoming event with `reminder_offset_minutes` set, calls `new Notification(event.title, { body: niceTimeString })`, caps the lookahead at 24 h, refreshes every 6 h, and tracks fired event ids in a `Set` ref so each event notifies at most once per page session. All timers and the refresh interval are cleared on unmount.
- `EventForm` reminder presets now also expose **1d before** alongside the existing None / At time / 5m / 15m / 30m / 1h chips.
- Vitest coverage for the new hook (permission gating, offset boundary, stale events, no-offset events, double-fire guard, 24h lookahead cap). Test count: 94 → 100, all green.

Closes #37

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test:run` (100/100 green)
- [ ] Manual: click **Enable notifications**, grant permission, create an event one minute in the future with `At time` offset, watch for the OS notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)