### PR TITLE
fix(realtime): add events to supabase_realtime publication — closes #39

### DIFF
--- a/supabase/migrations/004_events_realtime.sql
+++ b/supabase/migrations/004_events_realtime.sql
@@ -1,0 +1,22 @@
+-- 004_events_realtime.sql
+--
+-- The events table was supposed to live in the supabase_realtime publication
+-- per 001_initial_schema.sql, but it was missing from the live project's
+-- publication while todos was present (confirmed via pg_publication_tables
+-- on 2026-05-13). Cross-tab event sync therefore did not fire even though
+-- TodoContext sync worked. This migration adds public.events back
+-- (idempotent) so the realtime channel actually broadcasts INSERT/UPDATE/
+-- DELETE for events.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'events'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.events;
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

Companion to PR #81. The 2026-05-13 cross-tab verification (#39) caught that only \`todos\` was in the live publication; \`events\` was silently missing, so cross-tab event sync didn't fire.

Migration \`004_events_realtime.sql\` idempotently re-adds \`public.events\` to \`supabase_realtime\`. Applied to project \`dlzwktnvxzkqultwjstm\` via Supabase MCP \`apply_migration\`.

## Verification

Before:
\`\`\`sql
SELECT tablename FROM pg_publication_tables WHERE pubname = 'supabase_realtime';
-- [{ "tablename": "todos" }]
\`\`\`

After:
\`\`\`sql
-- [{ "tablename": "events" }, { "tablename": "todos" }]
\`\`\`

Closes #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)