### PR TITLE
fix(spa): read 404.html ?redirect= and navigate to deep link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router";
 import { Toaster } from "sonner";
 import ProtectedRoute from "./components/common/ProtectedRoute";
+import SpaRedirectHandler from "./components/common/SpaRedirectHandler";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { EventProvider } from "./contexts/EventContext";
@@ -30,6 +31,7 @@ export default function App() {
         <ThemeProvider>
           <EventProvider>
             <TodoProvider>
+              <SpaRedirectHandler />
               <Routes>
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/login" element={<LoginPage />} />

--- a/src/components/common/SpaRedirectHandler.tsx
+++ b/src/components/common/SpaRedirectHandler.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+/**
+ * Reads the `?redirect=<path>` query produced by `public/404.html` when
+ * GitHub Pages serves a deep link (e.g. /dashboard) that has no static
+ * file. The stub redirects the browser to the SPA root with the original
+ * path encoded in a query param; this component runs once on mount,
+ * decodes that param, and navigates to the saved path so deep links
+ * survive a hard reload.
+ */
+export default function SpaRedirectHandler() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const redirect = params.get("redirect");
+    if (!redirect) return;
+
+    // Strip the query param + navigate to the original path. `replace`
+    // keeps the back button clean.
+    navigate(redirect, { replace: true });
+  }, [location.search, navigate]);
+
+  return null;
+}


### PR DESCRIPTION
## Bug
Hard-reloading \`https://umutc.github.io/CSC-710-AI-Calendar/dashboard\` on the live deployment kicks the user back to the landing page instead of restoring \`/dashboard\`.

## Root cause
\`public/404.html\` redirects to \`/CSC-710-AI-Calendar/?redirect=%2Fdashboard\` (correct), but the app has no component reading the \`redirect\` param. The router mounts \`/\` → \`LandingPage\` and the URL change is silently ignored.

## Fix
New \`src/components/common/SpaRedirectHandler.tsx\`. Mounts once inside \`BrowserRouter\`; reads \`?redirect=\` on initial load and calls \`navigate(target, { replace: true })\`. ProtectedRoute then handles the auth check normally.

## Test plan
- [x] \`npm run build\` clean (2.7s)
- [x] \`npm run test:run\` 102/102 green
- [ ] After merge + Pages deploy: visit \`/dashboard\` while signed in → hard reload → URL stays on \`/dashboard\` and the dashboard renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)