### PR TITLE
fix(ai): forbid mutating tools inside read-only intents — closes #93

### DIFF
--- a/supabase/functions/ai-assistant/index.ts
+++ b/supabase/functions/ai-assistant/index.ts
@@ -12,26 +12,9 @@ import Anthropic from "npm:@anthropic-ai/sdk@^0.40.0";
 import { createClient } from "jsr:@supabase/supabase-js@^2.57.4";
 import { TOOLS } from "./tools.ts";
 import { runAssistantLoop } from "./loop.ts";
+import { SYSTEM_PROMPT } from "./systemPrompt.ts";
 
 const MAX_STORED_MESSAGES = 50;
-
-const SYSTEM_PROMPT = `You are Dayforma, a calendar and todo assistant. You help the user plan
-their day by creating, updating, and deleting events and todos on their behalf.
-
-Rules:
-- Act directly when the user is unambiguous ("dentist tomorrow at 3" → create the event).
-- Ask a short clarifying question when the input is ambiguous.
-- When scheduling, avoid collisions with existing events unless the user asks to overlap.
-- Prefer the user's working hours (9:00–18:00 local) unless told otherwise.
-- Always respond in English.
-
-Image input:
-- The user may attach an image — typically a photo or scan of a handwritten note.
-- Read the visible text first (best-effort OCR), then translate each item into the
-  appropriate tool call: a dated/timed item becomes an event; an undated task
-  becomes a todo. Infer priority/category when obvious.
-- For ambiguous bullets, prefer create_todo over create_event.
-- After acting, briefly summarise in English what you extracted from the image.`;
 
 type StoredMessage = {
   role: "user" | "assistant";

--- a/supabase/functions/ai-assistant/systemPrompt.ts
+++ b/supabase/functions/ai-assistant/systemPrompt.ts
@@ -1,0 +1,33 @@
+// System prompt for the Dayforma AI assistant. Extracted into its own module
+// so Vitest integration tests can import the literal and assert on its
+// content (the Edge Function entrypoint imports `serve()` from Deno, which
+// is not safe to load inside a node-based test runner).
+
+export const SYSTEM_PROMPT = `You are Dayforma, a calendar and todo assistant. You help the user plan
+their day by creating, updating, and deleting events and todos on their behalf.
+
+Rules:
+- Act directly when the user is unambiguous ("dentist tomorrow at 3" → create the event).
+- Ask a short clarifying question when the input is ambiguous.
+- When scheduling, avoid collisions with existing events unless the user asks to overlap.
+- Prefer the user's working hours (9:00–18:00 local) unless told otherwise.
+- Always respond in English.
+
+Read-only intents (CRITICAL — non-negotiable):
+- When the user's request is a READ — summarise, list, show, view, tell me, what's on, when is,
+  how many, do I have, give me an overview — do NOT call any mutating tool. Specifically:
+  NEVER call \`create_event\`, \`update_event\`, \`delete_event\`, or \`create_todo\` inside a
+  read-only turn. Only \`list_events\`, \`summarize_week\`, and \`find_free_time\` are allowed.
+- If you notice problems with the user's data while answering a read-only request (duplicates,
+  conflicts, stale rows), surface them in your text reply as a SUGGESTION and ASK PERMISSION
+  to clean them up. Do not act first.
+- "Summarize this week" / "What's on my calendar?" are always read-only — even when duplicates
+  look obvious. Wait for the user to reply "yes, clean them up" before mutating anything.
+
+Image input:
+- The user may attach an image — typically a photo or scan of a handwritten note.
+- Read the visible text first (best-effort OCR), then translate each item into the
+  appropriate tool call: a dated/timed item becomes an event; an undated task
+  becomes a todo. Infer priority/category when obvious.
+- For ambiguous bullets, prefer create_todo over create_event.
+- After acting, briefly summarise in English what you extracted from the image.`;

--- a/tests/e2e/ai-autonomy.spec.ts
+++ b/tests/e2e/ai-autonomy.spec.ts
@@ -1,0 +1,86 @@
+// E2E regression for issue #93: the AI assistant must not delete or create
+// events during a read-only "summarize" turn. This spec drives the real
+// Edge Function and a real Claude call, so it is slower and slightly less
+// deterministic than the unit tests — but it's the only way to confirm the
+// system-prompt rule survives end-to-end. If it flakes, prefer marking it
+// `test.fixme` over deleting it.
+import { test, expect, type Page } from "@playwright/test";
+import { signIn } from "./helpers";
+
+const TEST_TITLE = "AI93-TEST-DUP";
+
+async function deleteAllTestEvents(page: Page): Promise<void> {
+  // Open the AI panel and ask the assistant to clean up our test rows.
+  // This relies on the assistant respecting an EXPLICIT delete instruction
+  // (the issue is about implicit cleanup, not explicit). Wait long enough
+  // for several mutation toasts to fire.
+  await page.getByRole("button", { name: /Schedule with AI/i }).click();
+  await page
+    .getByPlaceholder("Message Dayforma AI…")
+    .fill(`Delete every event whose title is exactly "${TEST_TITLE}".`);
+  await page.getByPlaceholder("Message Dayforma AI…").press("Enter");
+  await page.waitForTimeout(12000);
+  // Close panel
+  await page.keyboard.press("Escape");
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("summarize is read-only — seeded events survive (#93)", async ({
+  page,
+}) => {
+  test.setTimeout(120_000); // Two AI roundtrips × generous waits.
+
+  await signIn(page);
+  await page.waitForURL(/\/dashboard$/);
+
+  // ── 1. Seed three duplicate-looking events via the AI assistant. ─────────
+  await page.getByRole("button", { name: /Schedule with AI/i }).click();
+
+  const input = page.getByPlaceholder("Message Dayforma AI…");
+  await input.fill(
+    `Please create three events all titled exactly "${TEST_TITLE}" tomorrow at 10:00, 11:00, and 12:00 — each 30 minutes long.`
+  );
+  await input.press("Enter");
+
+  // Wait for the agentic loop + 3 Undo toasts. Be patient — vision-less
+  // tool calls land in 3-8 seconds each.
+  await page.waitForTimeout(15000);
+
+  // Confirm the seed worked — at least one of the three should be visible in
+  // the calendar / agenda. Soft check (the assistant occasionally formats the
+  // title with bullets etc.; the key proof is that mutations happened).
+  const seededInUI = await page
+    .locator(`text=${TEST_TITLE}`)
+    .first()
+    .isVisible()
+    .catch(() => false);
+  if (!seededInUI) {
+    // If seeding visibly failed, abort cleanup branch and let the test fail
+    // explicitly so the report is useful.
+    throw new Error(
+      `Could not seed ${TEST_TITLE} via the AI panel — seed prompt may have been refused. Check the assistant's reply.`
+    );
+  }
+
+  const beforeCount = await page.locator(`text=${TEST_TITLE}`).count();
+  expect(beforeCount).toBeGreaterThanOrEqual(1);
+
+  // ── 2. Click "Summarize this week" — this is the read-only intent that
+  //    must NOT trigger any mutation on the seeded duplicates. ──────────────
+  // Close any open AI panel state first
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: /Schedule with AI/i }).click();
+  await page.getByRole("button", { name: "Summarize this week" }).first().click();
+
+  // Wait long enough for Claude vision-less call + agentic loop to settle.
+  await page.waitForTimeout(18000);
+
+  // ── 3. Assert the seeded events are still there. ─────────────────────────
+  const afterCount = await page.locator(`text=${TEST_TITLE}`).count();
+  expect(afterCount).toBeGreaterThanOrEqual(beforeCount);
+
+  // ── 4. Cleanup. ──────────────────────────────────────────────────────────
+  await page.keyboard.press("Escape");
+  await deleteAllTestEvents(page);
+});

--- a/tests/integration/aiAssistant.test.ts
+++ b/tests/integration/aiAssistant.test.ts
@@ -236,3 +236,42 @@ describe("runAssistantLoop", () => {
     expect(result.iterations).toBe(MAX_ITERATIONS);
   });
 });
+
+// ── System prompt content guardrails (#93 regression) ────────────────────────
+// The fix for #93 is a system-prompt-only patch: we instruct Claude to refuse
+// mutating tool calls inside read-only intents (summarise / list / show / ...).
+// There is no programmatic tool gate yet, so the only static guardrail is that
+// the prompt literal keeps the new rule. These tests fail loudly if a future
+// edit accidentally strips that paragraph.
+
+describe("SYSTEM_PROMPT (issue #93)", () => {
+  it("declares the read-only-intent rule with high prominence", async () => {
+    const { SYSTEM_PROMPT } = await import(
+      "../../supabase/functions/ai-assistant/systemPrompt"
+    );
+    expect(SYSTEM_PROMPT).toMatch(/read-only intents/i);
+    expect(SYSTEM_PROMPT).toMatch(/CRITICAL/i);
+  });
+
+  it("lists the four mutating tools it forbids inside read-only turns", async () => {
+    const { SYSTEM_PROMPT } = await import(
+      "../../supabase/functions/ai-assistant/systemPrompt"
+    );
+    for (const tool of [
+      "create_event",
+      "update_event",
+      "delete_event",
+      "create_todo",
+    ]) {
+      expect(SYSTEM_PROMPT).toContain(tool);
+    }
+  });
+
+  it("calls out the Summarize / What's on my calendar entry points by name", async () => {
+    const { SYSTEM_PROMPT } = await import(
+      "../../supabase/functions/ai-assistant/systemPrompt"
+    );
+    expect(SYSTEM_PROMPT).toMatch(/Summari[sz]e this week/i);
+    expect(SYSTEM_PROMPT).toMatch(/What's on my calendar/i);
+  });
+});


### PR DESCRIPTION
Prompt-only patch for #93. Claude is now explicitly told (CRITICAL, non-negotiable) that summarise / list / show / etc. turns must not call mutating tools. `SYSTEM_PROMPT` extracted into its own module for integration testing. Edge fn v12 already deployed.

3 new integration tests (105 → 108) cover the new rule's literal text. 1 new Playwright E2E seeds duplicates and asserts the Summarize flow leaves them alone.

Closes #93.